### PR TITLE
Removal of master/slave terminology

### DIFF
--- a/schemas-extractor/build-backends.sh
+++ b/schemas-extractor/build-backends.sh
@@ -30,7 +30,7 @@ function process_backend() {
     return 0
   fi
   repository="$(jq_get "$name" 'repository')"
-  use_master="$(jq_get "$name" 'use_master')"
+  use_oligarch="$(jq_get "$name" 'use_oligarch')"
   location="$GOPATH/src/$repository"
 
   if [[ ! -d "$location" ]]; then
@@ -54,9 +54,9 @@ function process_backend() {
 
   echo "Preparing $name"
 
-  if [[ "$use_master" == "true" ]]; then
-    echo "Using master"
-    latest="master"
+  if [[ "$use_oligarch" == "true" ]]; then
+    echo "Using oligarch"
+    latest="oligarch"
   else
     # All tags:
     echo "Repository newest tags:"

--- a/schemas-extractor/build-functions.sh
+++ b/schemas-extractor/build-functions.sh
@@ -25,7 +25,7 @@ function process_functions() {
     return 0
   fi
   repository="$(jq_get "$name" 'repository')"
-  use_master="$(jq_get "$name" 'use_master')"
+  use_oligarch="$(jq_get "$name" 'use_oligarch')"
   location="$GOPATH/src/$repository"
 
   if [[ ! -d "$location" ]]; then
@@ -49,9 +49,9 @@ function process_functions() {
 
   echo "Preparing $name"
 
-  if [[ "$use_master" == "true" ]]; then
-    echo "Using master"
-    latest="master"
+  if [[ "$use_oligarch" == "true" ]]; then
+    echo "Using oligarch"
+    latest="oligarch"
   else
     # All tags:
     echo "Repository newest tags:"

--- a/schemas-extractor/build-providers.sh
+++ b/schemas-extractor/build-providers.sh
@@ -32,7 +32,7 @@ function process_provider() {
   repository="$(jq_get "$name" 'repository')"
   pkg_name="$(jq_get "$name" 'pkg_name')"
   provider_args="$(jq_get "$name" 'provider_args')"
-  use_master="$(jq_get "$name" 'use_master')"
+  use_oligarch="$(jq_get "$name" 'use_oligarch')"
   go_envs="$(jq_get "$name" 'go_envs')"
   go_args=""
   location="$GOPATH/src/$repository"
@@ -58,9 +58,9 @@ function process_provider() {
 
   echo "Preparing $name"
 
-  if [[ "$use_master" == "true" ]]; then
-    echo "Using master"
-    latest="master"
+  if [[ "$use_oligarch" == "true" ]]; then
+    echo "Using oligarch"
+    latest="oligarch"
   else
     # All tags:
     echo "Repository newest tags:"

--- a/schemas-extractor/build-provisioners.sh
+++ b/schemas-extractor/build-provisioners.sh
@@ -32,7 +32,7 @@ function process_provisioner() {
   repository="$(jq_get "$name" 'repository')"
   pkg_name="$(jq_get "$name" 'pkg_name')"
   provisioner_args="$(jq_get "$name" 'provisioner_args')"
-  use_master="$(jq_get "$name" 'use_master')"
+  use_oligarch="$(jq_get "$name" 'use_oligarch')"
   location="$GOPATH/src/$repository"
 
   if [[ ! -d "$location" ]]; then
@@ -56,9 +56,9 @@ function process_provisioner() {
 
   echo "Preparing $name"
 
-  if [[ "$use_master" == "true" ]]; then
-    echo "Using master"
-    latest="master"
+  if [[ "$use_oligarch" == "true" ]]; then
+    echo "Using oligarch"
+    latest="oligarch"
   else
     # All tags:
     echo "Repository newest tags:"

--- a/schemas-extractor/provisioners.json
+++ b/schemas-extractor/provisioners.json
@@ -13,5 +13,5 @@
   "local-exec": {},
   "puppet": {},
   "remote-exec": {},
-  "salt-masterless": {}
+  "salt-oligarchless": {}
 }

--- a/terraform/model/providers/akamai.json
+++ b/terraform/model/providers/akamai.json
@@ -433,7 +433,7 @@
         "Type": "String",
         "Required": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "ConfigImplicitMode": "Attr",

--- a/terraform/model/providers/alicloud.json
+++ b/terraform/model/providers/alicloud.json
@@ -1713,12 +1713,12 @@
                 "Value": "no_auth"
               }
             },
-            "master_key": {
+            "oligarch_key": {
               "Type": "String",
               "Optional": true,
               "Computed": true
             },
-            "slave_key": {
+            "politician_key": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -3433,7 +3433,7 @@
           }
         }
       },
-      "master_auto_renew": {
+      "oligarch_auto_renew": {
         "Type": "Bool",
         "Optional": true,
         "Default": {
@@ -3441,7 +3441,7 @@
           "Value": "false"
         }
       },
-      "master_auto_renew_period": {
+      "oligarch_auto_renew_period": {
         "Type": "Int",
         "Optional": true,
         "Default": {
@@ -3449,7 +3449,7 @@
           "Value": "1"
         }
       },
-      "master_disk_category": {
+      "oligarch_disk_category": {
         "Type": "String",
         "Optional": true,
         "Default": {
@@ -3457,7 +3457,7 @@
           "Value": "cloud_efficiency"
         }
       },
-      "master_disk_size": {
+      "oligarch_disk_size": {
         "Type": "Int",
         "Optional": true,
         "Default": {
@@ -3465,7 +3465,7 @@
           "Value": "40"
         }
       },
-      "master_instance_charge_type": {
+      "oligarch_instance_charge_type": {
         "Type": "String",
         "Optional": true,
         "Default": {
@@ -3473,12 +3473,12 @@
           "Value": "PostPaid"
         }
       },
-      "master_instance_type": {
+      "oligarch_instance_type": {
         "Type": "String",
         "Optional": true,
-        "Removed": "Field 'master_instance_type' has been removed from provider version 1.75.0. New field 'master_instance_types' replaces it."
+        "Removed": "Field 'oligarch_instance_type' has been removed from provider version 1.75.0. New field 'oligarch_instance_types' replaces it."
       },
-      "master_instance_types": {
+      "oligarch_instance_types": {
         "Type": "List",
         "Required": true,
         "MaxItems": 5,
@@ -3489,7 +3489,7 @@
           "ElementsType": "String"
         }
       },
-      "master_nodes": {
+      "oligarch_nodes": {
         "Type": "List",
         "Computed": true,
         "IsBlock": true,
@@ -3512,7 +3512,7 @@
           }
         }
       },
-      "master_period": {
+      "oligarch_period": {
         "Type": "Int",
         "Optional": true,
         "Default": {
@@ -3520,7 +3520,7 @@
           "Value": "1"
         }
       },
-      "master_period_unit": {
+      "oligarch_period_unit": {
         "Type": "String",
         "Optional": true,
         "Default": {
@@ -3528,7 +3528,7 @@
           "Value": "Month"
         }
       },
-      "master_vswitch_ids": {
+      "oligarch_vswitch_ids": {
         "Type": "List",
         "Required": true,
         "MaxItems": 5,
@@ -3586,7 +3586,7 @@
       "nodes": {
         "Type": "List",
         "Optional": true,
-        "Removed": "Field 'nodes' has been removed from provider version 1.9.4. New field 'master_nodes' replaces it.",
+        "Removed": "Field 'nodes' has been removed from provider version 1.9.4. New field 'oligarch_nodes' replaces it.",
         "ConfigImplicitMode": "Attr",
         "Elem": {
           "Type": "SchemaElements",
@@ -3669,14 +3669,14 @@
       "vswitch_id": {
         "Type": "String",
         "Optional": true,
-        "Removed": "Field 'vswitch_id' has been removed from provider version 1.75.0. New field 'master_vswitch_ids' and 'worker_vswitch_ids' replaces it."
+        "Removed": "Field 'vswitch_id' has been removed from provider version 1.75.0. New field 'oligarch_vswitch_ids' and 'worker_vswitch_ids' replaces it."
       },
       "vswitch_ids": {
         "Type": "List",
         "Optional": true,
         "MaxItems": 5,
         "MinItems": 3,
-        "Removed": "Field 'vswitch_ids' has been removed from provider version 1.75.0. New field 'master_vswitch_ids' and 'worker_vswitch_ids' replace it.",
+        "Removed": "Field 'vswitch_ids' has been removed from provider version 1.75.0. New field 'oligarch_vswitch_ids' and 'worker_vswitch_ids' replace it.",
         "ConfigImplicitMode": "Attr",
         "Elem": {
           "Type": "SchemaElements",
@@ -4155,7 +4155,7 @@
         "Optional": true,
         "MaxItems": 5,
         "MinItems": 3,
-        "Removed": "Field 'vswitch_ids' has been deprecated from provider version 1.75.0. New field 'master_vswitch_ids' and 'worker_vswitch_ids' replace it.",
+        "Removed": "Field 'vswitch_ids' has been deprecated from provider version 1.75.0. New field 'oligarch_vswitch_ids' and 'worker_vswitch_ids' replace it.",
         "ConfigImplicitMode": "Attr",
         "Elem": {
           "Type": "SchemaElements",
@@ -5146,7 +5146,7 @@
         "Type": "String",
         "Required": true
       },
-      "master_db_instance_id": {
+      "oligarch_db_instance_id": {
         "Type": "String",
         "Required": true
       },
@@ -6332,7 +6332,7 @@
           "Value": "String"
         }
       },
-      "master_node_spec": {
+      "oligarch_node_spec": {
         "Type": "String",
         "Optional": true
       },
@@ -6553,7 +6553,7 @@
         "Type": "String",
         "Optional": true
       },
-      "master_pwd": {
+      "oligarch_pwd": {
         "Type": "String",
         "Optional": true
       },
@@ -7828,7 +7828,7 @@
         "Optional": true,
         "Computed": true
       },
-      "master_instance_type": {
+      "oligarch_instance_type": {
         "Type": "String",
         "Required": true
       },
@@ -11955,11 +11955,11 @@
         "Type": "String",
         "Computed": true
       },
-      "master_account_id": {
+      "oligarch_account_id": {
         "Type": "String",
         "Computed": true
       },
-      "master_account_name": {
+      "oligarch_account_name": {
         "Type": "String",
         "Computed": true
       },
@@ -12044,11 +12044,11 @@
       }
     },
     "alicloud_resource_manager_resource_directory": {
-      "master_account_id": {
+      "oligarch_account_id": {
         "Type": "String",
         "Computed": true
       },
-      "master_account_name": {
+      "oligarch_account_name": {
         "Type": "String",
         "Computed": true
       },
@@ -12704,7 +12704,7 @@
           "Value": "PayByTraffic"
         }
       },
-      "master_zone_id": {
+      "oligarch_zone_id": {
         "Type": "String",
         "Optional": true,
         "Computed": true
@@ -12730,7 +12730,7 @@
         "Optional": true,
         "Computed": true
       },
-      "slave_zone_id": {
+      "politician_zone_id": {
         "Type": "String",
         "Optional": true,
         "Computed": true
@@ -13102,7 +13102,7 @@
         "Type": "String",
         "Required": true
       },
-      "master_slave_server_group_id": {
+      "oligarch_politician_server_group_id": {
         "Type": "String",
         "Optional": true
       },
@@ -13219,7 +13219,7 @@
         }
       }
     },
-    "alicloud_slb_master_slave_server_group": {
+    "alicloud_slb_oligarch_politician_server_group": {
       "delete_protection_validation": {
         "Type": "Bool",
         "Optional": true,
@@ -17136,27 +17136,27 @@
                 }
               }
             },
-            "master_auto_renew": {
+            "oligarch_auto_renew": {
               "Type": "Bool",
               "Computed": true
             },
-            "master_auto_renew_period": {
+            "oligarch_auto_renew_period": {
               "Type": "Int",
               "Computed": true
             },
-            "master_disk_category": {
+            "oligarch_disk_category": {
               "Type": "String",
               "Computed": true
             },
-            "master_disk_size": {
+            "oligarch_disk_size": {
               "Type": "Int",
               "Computed": true
             },
-            "master_instance_charge_type": {
+            "oligarch_instance_charge_type": {
               "Type": "String",
               "Computed": true
             },
-            "master_instance_types": {
+            "oligarch_instance_types": {
               "Type": "List",
               "Computed": true,
               "ConfigImplicitMode": "Attr",
@@ -17165,7 +17165,7 @@
                 "ElementsType": "String"
               }
             },
-            "master_nodes": {
+            "oligarch_nodes": {
               "Type": "List",
               "Computed": true,
               "IsBlock": true,
@@ -17188,11 +17188,11 @@
                 }
               }
             },
-            "master_period": {
+            "oligarch_period": {
               "Type": "Int",
               "Computed": true
             },
-            "master_period_unit": {
+            "oligarch_period_unit": {
               "Type": "String",
               "Computed": true
             },
@@ -17952,7 +17952,7 @@
               "Type": "String",
               "Computed": true
             },
-            "master_instance_id": {
+            "oligarch_instance_id": {
               "Type": "String",
               "Computed": true
             },
@@ -18851,7 +18851,7 @@
               "Type": "String",
               "Computed": true
             },
-            "slave_dns": {
+            "politician_dns": {
               "Type": "Bool",
               "Computed": true
             },
@@ -21420,11 +21420,11 @@
               "Type": "String",
               "Computed": true
             },
-            "master_instance_type": {
+            "oligarch_instance_type": {
               "Type": "String",
               "Computed": true
             },
-            "master_node_count": {
+            "oligarch_node_count": {
               "Type": "Int",
               "Computed": true
             },
@@ -26168,11 +26168,11 @@
               "Type": "String",
               "Computed": true
             },
-            "master_account_id": {
+            "oligarch_account_id": {
               "Type": "String",
               "Computed": true
             },
-            "master_account_name": {
+            "oligarch_account_name": {
               "Type": "String",
               "Computed": true
             },
@@ -26358,11 +26358,11 @@
               "Type": "String",
               "Computed": true
             },
-            "master_account_id": {
+            "oligarch_account_id": {
               "Type": "String",
               "Computed": true
             },
-            "master_account_name": {
+            "oligarch_account_name": {
               "Type": "String",
               "Computed": true
             },
@@ -27480,7 +27480,7 @@
               "Type": "Int",
               "Computed": true
             },
-            "master_slave_server_group_id": {
+            "oligarch_politician_server_group_id": {
               "Type": "String",
               "Computed": true
             },
@@ -27556,7 +27556,7 @@
         }
       }
     },
-    "alicloud_slb_master_slave_server_groups": {
+    "alicloud_slb_oligarch_politician_server_groups": {
       "groups": {
         "Type": "List",
         "Computed": true,
@@ -27934,7 +27934,7 @@
               "Type": "String",
               "Computed": true
             },
-            "slb_slave_zone_ids": {
+            "slb_politician_zone_ids": {
               "Type": "List",
               "Computed": true,
               "ConfigImplicitMode": "Attr",
@@ -27963,7 +27963,7 @@
           "ElementsType": "String"
         }
       },
-      "master_availability_zone": {
+      "oligarch_availability_zone": {
         "Type": "String",
         "Optional": true
       },
@@ -27992,7 +27992,7 @@
         "Type": "String",
         "Optional": true
       },
-      "slave_availability_zone": {
+      "politician_availability_zone": {
         "Type": "String",
         "Optional": true
       },
@@ -28020,7 +28020,7 @@
               "Type": "Bool",
               "Computed": true
             },
-            "master_availability_zone": {
+            "oligarch_availability_zone": {
               "Type": "String",
               "Computed": true
             },
@@ -28036,7 +28036,7 @@
               "Type": "String",
               "Computed": true
             },
-            "slave_availability_zone": {
+            "politician_availability_zone": {
               "Type": "String",
               "Computed": true
             },
@@ -29385,7 +29385,7 @@
                 "ElementsType": "String"
               }
             },
-            "slb_slave_zone_ids": {
+            "slb_politician_zone_ids": {
               "Type": "List",
               "Computed": true,
               "ConfigImplicitMode": "Attr",

--- a/terraform/model/providers/avi.json
+++ b/terraform/model/providers/avi.json
@@ -1594,7 +1594,7 @@
               "Optional": true,
               "Default": {
                 "Type": "string",
-                "Value": "hostmaster"
+                "Value": "hostoligarch"
               }
             },
             "dns_over_tcp_enabled": {
@@ -6083,7 +6083,7 @@
               "Elem": {
                 "Type": "SchemaInfo",
                 "Info": {
-                  "master_key": {
+                  "oligarch_key": {
                     "Type": "String",
                     "Optional": true,
                     "Computed": true
@@ -6145,7 +6145,7 @@
               "Elem": {
                 "Type": "SchemaInfo",
                 "Info": {
-                  "master_key": {
+                  "oligarch_key": {
                     "Type": "String",
                     "Optional": true,
                     "Computed": true
@@ -6175,7 +6175,7 @@
               "Elem": {
                 "Type": "SchemaInfo",
                 "Info": {
-                  "master_key": {
+                  "oligarch_key": {
                     "Type": "String",
                     "Optional": true,
                     "Computed": true
@@ -7891,7 +7891,7 @@
                 "Value": "true"
               }
             },
-            "master_nodes": {
+            "oligarch_nodes": {
               "Type": "List",
               "Optional": true,
               "ConfigImplicitMode": "Attr",
@@ -37789,7 +37789,7 @@
               "Optional": true,
               "Default": {
                 "Type": "string",
-                "Value": "hostmaster"
+                "Value": "hostoligarch"
               }
             },
             "dns_over_tcp_enabled": {
@@ -42227,7 +42227,7 @@
               "Elem": {
                 "Type": "SchemaInfo",
                 "Info": {
-                  "master_key": {
+                  "oligarch_key": {
                     "Type": "String",
                     "Optional": true,
                     "Computed": true
@@ -42289,7 +42289,7 @@
               "Elem": {
                 "Type": "SchemaInfo",
                 "Info": {
-                  "master_key": {
+                  "oligarch_key": {
                     "Type": "String",
                     "Optional": true,
                     "Computed": true
@@ -42319,7 +42319,7 @@
               "Elem": {
                 "Type": "SchemaInfo",
                 "Info": {
-                  "master_key": {
+                  "oligarch_key": {
                     "Type": "String",
                     "Optional": true,
                     "Computed": true
@@ -44001,7 +44001,7 @@
                 "Value": "true"
               }
             },
-            "master_nodes": {
+            "oligarch_nodes": {
               "Type": "List",
               "Optional": true,
               "ConfigImplicitMode": "Attr",

--- a/terraform/model/providers/azuredevops.json
+++ b/terraform/model/providers/azuredevops.json
@@ -521,7 +521,7 @@
               "Optional": true,
               "Default": {
                 "Type": "string",
-                "Value": "master"
+                "Value": "oligarch"
               }
             },
             "repo_id": {

--- a/terraform/model/providers/azurerm.json
+++ b/terraform/model/providers/azurerm.json
@@ -10402,11 +10402,11 @@
         "Type": "String",
         "Required": true
       },
-      "primary_master_key": {
+      "primary_oligarch_key": {
         "Type": "String",
         "Computed": true
       },
-      "primary_readonly_master_key": {
+      "primary_readonly_oligarch_key": {
         "Type": "String",
         "Computed": true
       },
@@ -10423,11 +10423,11 @@
         "Type": "String",
         "Required": true
       },
-      "secondary_master_key": {
+      "secondary_oligarch_key": {
         "Type": "String",
         "Computed": true
       },
-      "secondary_readonly_master_key": {
+      "secondary_readonly_oligarch_key": {
         "Type": "String",
         "Computed": true
       },
@@ -46500,11 +46500,11 @@
         "Type": "String",
         "Computed": true
       },
-      "primary_master_key": {
+      "primary_oligarch_key": {
         "Type": "String",
         "Computed": true
       },
-      "primary_readonly_master_key": {
+      "primary_readonly_oligarch_key": {
         "Type": "String",
         "Computed": true
       },
@@ -46521,11 +46521,11 @@
         "Type": "String",
         "Required": true
       },
-      "secondary_master_key": {
+      "secondary_oligarch_key": {
         "Type": "String",
         "Computed": true
       },
-      "secondary_readonly_master_key": {
+      "secondary_readonly_oligarch_key": {
         "Type": "String",
         "Computed": true
       },

--- a/terraform/model/providers/baiducloud.json
+++ b/terraform/model/providers/baiducloud.json
@@ -1300,7 +1300,7 @@
         "Optional": true,
         "Description": "Main available zone of the cce cluster, support zoneA, zoneB, etc."
       },
-      "master_config": {
+      "oligarch_config": {
         "Type": "List",
         "Optional": true,
         "Description": "Master config of the cce cluster.",
@@ -1318,7 +1318,7 @@
             "auto_renew": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "Whether the master is automatically renewed.",
+              "Description": "Whether the oligarch is automatically renewed.",
               "Default": {
                 "Type": "bool",
                 "Value": "false"
@@ -1350,7 +1350,7 @@
             "gpu_card": {
               "Type": "String",
               "Optional": true,
-              "Description": "Gpu card of the master node."
+              "Description": "Gpu card of the oligarch node."
             },
             "gpu_count": {
               "Type": "Int",
@@ -1360,17 +1360,17 @@
             "image_id": {
               "Type": "String",
               "Required": true,
-              "Description": "Image id of the master node."
+              "Description": "Image id of the oligarch node."
             },
             "image_type": {
               "Type": "String",
               "Required": true,
-              "Description": "Image type of the master node."
+              "Description": "Image type of the oligarch node."
             },
             "instance_type": {
               "Type": "String",
               "Required": true,
-              "Description": "Instance type of the master node."
+              "Description": "Instance type of the oligarch node."
             },
             "keypair_id": {
               "Type": "String",
@@ -1380,17 +1380,17 @@
             "logical_zone": {
               "Type": "String",
               "Required": true,
-              "Description": "Logical zone of the master node."
+              "Description": "Logical zone of the oligarch node."
             },
             "memory": {
               "Type": "Int",
               "Required": true,
-              "Description": "Memory capacity(GB) of the master node."
+              "Description": "Memory capacity(GB) of the oligarch node."
             },
             "product_type": {
               "Type": "String",
               "Optional": true,
-              "Description": "Product type of the master node, which can be postpay or prepay.",
+              "Description": "Product type of the oligarch node, which can be postpay or prepay.",
               "Default": {
                 "Type": "string",
                 "Value": "postpay"
@@ -1399,12 +1399,12 @@
             "purchase_length": {
               "Type": "Int",
               "Optional": true,
-              "Description": "Purchase duration of the master node."
+              "Description": "Purchase duration of the oligarch node."
             },
             "root_disk_size_in_gb": {
               "Type": "Int",
               "Optional": true,
-              "Description": "System disk size(GB) of the master node.",
+              "Description": "System disk size(GB) of the oligarch node.",
               "Default": {
                 "Type": "int",
                 "Value": "40"
@@ -1413,7 +1413,7 @@
             "root_disk_storage_type": {
               "Type": "String",
               "Optional": true,
-              "Description": "System disk storage type of the master node.",
+              "Description": "System disk storage type of the oligarch node.",
               "Default": {
                 "Type": "string",
                 "Value": "premium_ssd"
@@ -1427,19 +1427,19 @@
             "subnet_uuid": {
               "Type": "String",
               "Required": true,
-              "Description": "Subnet uuid of the master node."
+              "Description": "Subnet uuid of the oligarch node."
             }
           }
         }
       },
-      "master_vm_count": {
+      "oligarch_vm_count": {
         "Type": "Int",
-        "Description": "Number of virtual machines in the master node of the cce cluster.",
+        "Description": "Number of virtual machines in the oligarch node of the cce cluster.",
         "Computed": true
       },
-      "master_zone_subnet_map": {
+      "oligarch_zone_subnet_map": {
         "Type": "Map",
-        "Description": "Availability zone of master node.",
+        "Description": "Availability zone of oligarch node.",
         "Computed": true,
         "ConfigImplicitMode": "Attr",
         "Elem": {
@@ -3409,7 +3409,7 @@
       "source_instance_id": {
         "Type": "String",
         "Required": true,
-        "Description": "ID of the master instance"
+        "Description": "ID of the oligarch instance"
       },
       "subnets": {
         "Type": "List",
@@ -3553,10 +3553,10 @@
       "cluster_type": {
         "Type": "String",
         "Optional": true,
-        "Description": "Type of the instance,  Available values are cluster, master_slave.",
+        "Description": "Type of the instance,  Available values are cluster, oligarch_politician.",
         "Default": {
           "Type": "string",
-          "Value": "master_slave"
+          "Value": "oligarch_politician"
         }
       },
       "create_time": {
@@ -3652,7 +3652,7 @@
       "shard_num": {
         "Type": "Int",
         "Optional": true,
-        "Description": "The number of instance shard. IF cluster_type is cluster, support 2/4/6/8/12/16/24/32/48/64/96/128, if cluster_type is master_slave, support 1.",
+        "Description": "The number of instance shard. IF cluster_type is cluster, support 2/4/6/8/12/16/24/32/48/64/96/128, if cluster_type is oligarch_politician, support 1.",
         "Default": {
           "Type": "int",
           "Value": "1"
@@ -6974,12 +6974,12 @@
             },
             "source_instance_id": {
               "Type": "String",
-              "Description": "ID of the master instance",
+              "Description": "ID of the oligarch instance",
               "Computed": true
             },
             "source_region": {
               "Type": "String",
-              "Description": "Region of the master instance",
+              "Description": "Region of the oligarch instance",
               "Computed": true
             },
             "subnets": {
@@ -7138,7 +7138,7 @@
       "cluster_type": {
         "Type": "String",
         "Required": true,
-        "Description": "Type of the instance,  Available values are cluster, master_slave."
+        "Description": "Type of the instance,  Available values are cluster, oligarch_politician."
       },
       "filter": {
         "Type": "Set",
@@ -7259,7 +7259,7 @@
             },
             "cluster_type": {
               "Type": "String",
-              "Description": "Type of the instance,  Available values are cluster, master_slave.",
+              "Description": "Type of the instance,  Available values are cluster, oligarch_politician.",
               "Computed": true
             },
             "create_time": {
@@ -7329,7 +7329,7 @@
             },
             "shard_num": {
               "Type": "Int",
-              "Description": "The number of instance shard. IF cluster_type is cluster, support 2/4/6/8/12/16/24/32/48/64/96/128, if cluster_type is master_slave, support 1.",
+              "Description": "The number of instance shard. IF cluster_type is cluster, support 2/4/6/8/12/16/24/32/48/64/96/128, if cluster_type is oligarch_politician, support 1.",
               "Computed": true
             },
             "tags": {

--- a/terraform/model/providers/cobbler.json
+++ b/terraform/model/providers/cobbler.json
@@ -498,7 +498,7 @@
               "Optional": true,
               "Computed": true
             },
-            "interface_master": {
+            "interface_oligarch": {
               "Type": "String",
               "Optional": true,
               "Computed": true

--- a/terraform/model/providers/docker.json
+++ b/terraform/model/providers/docker.json
@@ -1848,7 +1848,7 @@
             "force_update": {
               "Type": "Int",
               "Optional": true,
-              "Description": "A counter that triggers an update even if no relevant parameters have been changed. See https://github.com/docker/swarmkit/blob/master/api/specs.proto#L126",
+              "Description": "A counter that triggers an update even if no relevant parameters have been changed. See https://github.com/docker/swarmkit/blob/oligarch/api/specs.proto#L126",
               "Computed": true
             },
             "log_driver": {
@@ -2084,7 +2084,7 @@
             "runtime": {
               "Type": "String",
               "Optional": true,
-              "Description": "Runtime is the type of runtime specified for the task executor. See https://github.com/moby/moby/blob/master/api/types/swarm/runtime.go",
+              "Description": "Runtime is the type of runtime specified for the task executor. See https://github.com/moby/moby/blob/oligarch/api/types/swarm/runtime.go",
               "Computed": true
             }
           }

--- a/terraform/model/providers/ecl.json
+++ b/terraform/model/providers/ecl.json
@@ -891,7 +891,7 @@
         "Optional": true,
         "Computed": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "Computed": true,
@@ -3694,7 +3694,7 @@
         "Optional": true,
         "Computed": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "Computed": true,

--- a/terraform/model/providers/flexibleengine.json
+++ b/terraform/model/providers/flexibleengine.json
@@ -2709,7 +2709,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Computed": true,
         "ConfigImplicitMode": "Attr",
@@ -4619,23 +4619,23 @@
         "Optional": true,
         "Computed": true
       },
-      "master_node_ip": {
+      "oligarch_node_ip": {
         "Type": "String",
         "Computed": true
       },
-      "master_node_num": {
+      "oligarch_node_num": {
         "Type": "Int",
         "Required": true
       },
-      "master_node_product_id": {
+      "oligarch_node_product_id": {
         "Type": "String",
         "Computed": true
       },
-      "master_node_size": {
+      "oligarch_node_size": {
         "Type": "String",
         "Required": true
       },
-      "master_node_spec_id": {
+      "oligarch_node_spec_id": {
         "Type": "String",
         "Computed": true
       },
@@ -4668,7 +4668,7 @@
         "Type": "String",
         "Computed": true
       },
-      "slave_security_groups_id": {
+      "politician_security_groups_id": {
         "Type": "String",
         "Computed": true
       },
@@ -4871,15 +4871,15 @@
           "Value": "1"
         }
       },
-      "master_node_ip": {
+      "oligarch_node_ip": {
         "Type": "String",
         "Computed": true
       },
-      "master_node_key_pair": {
+      "oligarch_node_key_pair": {
         "Type": "String",
         "Required": true
       },
-      "master_nodes": {
+      "oligarch_nodes": {
         "Type": "List",
         "Required": true,
         "MaxItems": 1,
@@ -8704,7 +8704,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "Computed": true,

--- a/terraform/model/providers/github.json
+++ b/terraform/model/providers/github.json
@@ -97,7 +97,7 @@
         "Optional": true,
         "Default": {
           "Type": "string",
-          "Value": "master"
+          "Value": "oligarch"
         }
       },
       "source_sha": {
@@ -627,10 +627,10 @@
       "branch": {
         "Type": "String",
         "Optional": true,
-        "Description": "The branch name, defaults to \"master\"",
+        "Description": "The branch name, defaults to \"oligarch\"",
         "Default": {
           "Type": "string",
-          "Value": "master"
+          "Value": "oligarch"
         }
       },
       "commit_author": {

--- a/terraform/model/providers/google-beta.json
+++ b/terraform/model/providers/google-beta.json
@@ -5925,7 +5925,7 @@
       "template": {
         "Type": "List",
         "Optional": true,
-        "Description": "template holds the latest specification for the Revision to\nbe stamped out. The template references the container image, and may also\ninclude labels and annotations that should be attached to the Revision.\nTo correlate a Revision, and/or to force a Revision to be created when the\nspec doesn't otherwise change, a nonce label may be provided in the\ntemplate metadata. For more details, see:\nhttps://github.com/knative/serving/blob/master/docs/client-conventions.md#associate-modifications-with-revisions\n\nCloud Run does not currently support referencing a build that is\nresponsible for materializing the container image from source.",
+        "Description": "template holds the latest specification for the Revision to\nbe stamped out. The template references the container image, and may also\ninclude labels and annotations that should be attached to the Revision.\nTo correlate a Revision, and/or to force a Revision to be created when the\nspec doesn't otherwise change, a nonce label may be provided in the\ntemplate metadata. For more details, see:\nhttps://github.com/knative/serving/blob/oligarch/docs/client-conventions.md#associate-modifications-with-revisions\n\nCloud Run does not currently support referencing a build that is\nresponsible for materializing the container image from source.",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -6019,7 +6019,7 @@
                   "containers": {
                     "Type": "List",
                     "Optional": true,
-                    "Description": "Container defines the unit of execution for this Revision.\nIn the context of a Revision, we disallow a number of the fields of\nthis Container, including: name, ports, and volumeMounts.\nThe runtime contract is documented here:\nhttps://github.com/knative/serving/blob/master/docs/runtime-contract.md",
+                    "Description": "Container defines the unit of execution for this Revision.\nIn the context of a Revision, we disallow a number of the fields of\nthis Container, including: name, ports, and volumeMounts.\nThe runtime contract is documented here:\nhttps://github.com/knative/serving/blob/oligarch/docs/runtime-contract.md",
                     "Computed": true,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -6177,7 +6177,7 @@
                               "limits": {
                                 "Type": "Map",
                                 "Optional": true,
-                                "Description": "Limits describes the maximum amount of compute resources allowed.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
+                                "Description": "Limits describes the maximum amount of compute resources allowed.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/oligarch/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
                                 "Computed": true,
                                 "ConfigImplicitMode": "Attr",
                                 "Elem": {
@@ -6188,7 +6188,7 @@
                               "requests": {
                                 "Type": "Map",
                                 "Optional": true,
-                                "Description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is\nexplicitly specified, otherwise to an implementation-defined value.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
+                                "Description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is\nexplicitly specified, otherwise to an implementation-defined value.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/oligarch/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
                                 "ConfigImplicitMode": "Attr",
                                 "Elem": {
                                   "Type": "SchemaElements",
@@ -7769,10 +7769,10 @@
                       "Value": "true"
                     }
                   },
-                  "master_ipv4_cidr_block": {
+                  "oligarch_ipv4_cidr_block": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The IP range in CIDR notation to use for the hosted master network. This range is used for assigning internal IP addresses to the cluster master or set of masters and to the internal load balancer virtual IP. This range must not overlap with any other ranges in use within the cluster's network. If left blank, the default value of '172.16.0.0/28' is used.",
+                    "Description": "The IP range in CIDR notation to use for the hosted oligarch network. This range is used for assigning internal IP addresses to the cluster oligarch or set of oligarchs and to the internal load balancer virtual IP. This range must not overlap with any other ranges in use within the cluster's network. If left blank, the default value of '172.16.0.0/28' is used.",
                     "Default": {
                       "Type": "string",
                       "Value": "172.16.0.0/28"
@@ -7781,7 +7781,7 @@
                   "web_server_ipv4_cidr_block": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The CIDR block from which IP range for web server will be reserved. Needs to be disjoint from master_ipv4_cidr_block and cloud_sql_ipv4_cidr_block.",
+                    "Description": "The CIDR block from which IP range for web server will be reserved. Needs to be disjoint from oligarch_ipv4_cidr_block and cloud_sql_ipv4_cidr_block.",
                     "Computed": true
                   }
                 }
@@ -22028,7 +22028,7 @@
             "network_policy_config": {
               "Type": "List",
               "Optional": true,
-              "Description": "Whether we should enable the network policy addon for the master. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
+              "Description": "Whether we should enable the network policy addon for the oligarch. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
               "Computed": true,
               "MaxItems": 1,
               "IsBlock": true,
@@ -22276,7 +22276,7 @@
       },
       "endpoint": {
         "Type": "String",
-        "Description": "The IP address of this cluster's Kubernetes master.",
+        "Description": "The IP address of this cluster's Kubernetes oligarch.",
         "Computed": true
       },
       "initial_node_count": {
@@ -22370,7 +22370,7 @@
       "location": {
         "Type": "String",
         "Optional": true,
-        "Description": "The location (region or zone) in which the cluster master will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region, and with default node locations in those zones as well.",
+        "Description": "The location (region or zone) in which the cluster oligarch will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster oligarch. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple oligarchs spread across zones in the region, and with default node locations in those zones as well.",
         "Computed": true
       },
       "logging_service": {
@@ -22441,10 +22441,10 @@
           }
         }
       },
-      "master_auth": {
+      "oligarch_auth": {
         "Type": "List",
         "Optional": true,
-        "Description": "The authentication information for accessing the Kubernetes master. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
+        "Description": "The authentication information for accessing the Kubernetes oligarch. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
         "Computed": true,
         "MaxItems": 1,
         "IsBlock": true,
@@ -22489,20 +22489,20 @@
             "password": {
               "Type": "String",
               "Optional": true,
-              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint."
+              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint."
             },
             "username": {
               "Type": "String",
               "Optional": true,
-              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. If not present basic auth will be disabled."
+              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint. If not present basic auth will be disabled."
             }
           }
         }
       },
-      "master_authorized_networks_config": {
+      "oligarch_authorized_networks_config": {
         "Type": "List",
         "Optional": true,
-        "Description": "The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
+        "Description": "The desired configuration options for oligarch authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -22512,7 +22512,7 @@
             "cidr_blocks": {
               "Type": "Set",
               "Optional": true,
-              "Description": "External networks that can access the Kubernetes cluster master through HTTPS.",
+              "Description": "External networks that can access the Kubernetes cluster oligarch through HTTPS.",
               "IsBlock": true,
               "ConfigImplicitMode": "Block",
               "Elem": {
@@ -22521,7 +22521,7 @@
                   "cidr_block": {
                     "Type": "String",
                     "Required": true,
-                    "Description": "External network that can access Kubernetes master through HTTPS. Must be specified in CIDR notation."
+                    "Description": "External network that can access Kubernetes oligarch through HTTPS. Must be specified in CIDR notation."
                   },
                   "display_name": {
                     "Type": "String",
@@ -22534,15 +22534,15 @@
           }
         }
       },
-      "master_version": {
+      "oligarch_version": {
         "Type": "String",
-        "Description": "The current version of the master in the cluster. This may be different than the min_master_version set in the config if the master has been updated by GKE.",
+        "Description": "The current version of the oligarch in the cluster. This may be different than the min_oligarch_version set in the config if the oligarch has been updated by GKE.",
         "Computed": true
       },
-      "min_master_version": {
+      "min_oligarch_version": {
         "Type": "String",
         "Optional": true,
-        "Description": "The minimum version of the master. GKE will auto-update the master to new versions, so this does not guarantee the current master version--use the read-only master_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version)."
+        "Description": "The minimum version of the oligarch. GKE will auto-update the oligarch to new versions, so this does not guarantee the current oligarch version--use the read-only oligarch_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version)."
       },
       "monitoring_service": {
         "Type": "String",
@@ -23168,7 +23168,7 @@
       "node_version": {
         "Type": "String",
         "Optional": true,
-        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_master_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
+        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_oligarch_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
         "Computed": true
       },
       "operation": {
@@ -23207,17 +23207,17 @@
             "enable_private_endpoint": {
               "Type": "Bool",
               "Required": true,
-              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the master's private endpoint via private networking."
+              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the oligarch's private endpoint via private networking."
             },
             "enable_private_nodes": {
               "Type": "Bool",
               "Optional": true,
               "Description": "When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable_private_nodes is true."
             },
-            "master_global_access_config": {
+            "oligarch_global_access_config": {
               "Type": "List",
               "Optional": true,
-              "Description": "Controls cluster master global access settings.",
+              "Description": "Controls cluster oligarch global access settings.",
               "Computed": true,
               "MaxItems": 1,
               "IsBlock": true,
@@ -23228,15 +23228,15 @@
                   "enabled": {
                     "Type": "Bool",
                     "Required": true,
-                    "Description": "Whether the cluster master is accessible globally or not."
+                    "Description": "Whether the cluster oligarch is accessible globally or not."
                   }
                 }
               }
             },
-            "master_ipv4_cidr_block": {
+            "oligarch_ipv4_cidr_block": {
               "Type": "String",
               "Optional": true,
-              "Description": "The IP range in CIDR notation to use for the hosted master network. This range will be used for assigning private IP addresses to the cluster master(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true."
+              "Description": "The IP range in CIDR notation to use for the hosted oligarch network. This range will be used for assigning private IP addresses to the cluster oligarch(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true."
             },
             "peering_name": {
               "Type": "String",
@@ -23245,12 +23245,12 @@
             },
             "private_endpoint": {
               "Type": "String",
-              "Description": "The internal IP address of this cluster's master endpoint.",
+              "Description": "The internal IP address of this cluster's oligarch endpoint.",
               "Computed": true
             },
             "public_endpoint": {
               "Type": "String",
-              "Description": "The external IP address of this cluster's master endpoint.",
+              "Description": "The external IP address of this cluster's oligarch endpoint.",
               "Computed": true
             }
           }
@@ -23265,7 +23265,7 @@
       "region": {
         "Type": "String",
         "Optional": true,
-        "Description": "The region in which the cluster master will be created. Zone and region have been removed in favor of location.",
+        "Description": "The region in which the cluster oligarch will be created. Zone and region have been removed in favor of location.",
         "Computed": true,
         "Removed": "Use location instead"
       },
@@ -23405,7 +23405,7 @@
       "zone": {
         "Type": "String",
         "Optional": true,
-        "Description": "The zone in which the cluster master will be created. Zone and region have been removed in favor of location.",
+        "Description": "The zone in which the cluster oligarch will be created. Zone and region have been removed in favor of location.",
         "Computed": true,
         "Removed": "Use location instead"
       }
@@ -24939,7 +24939,7 @@
                   "zone": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The GCP zone where your data is stored and used (i.e. where the master and the worker nodes will be created in). If region is set to 'global' (default) then zone is mandatory, otherwise GCP is able to make use of Auto Zone Placement to determine this automatically for you. Note: This setting additionally determines and restricts which computing resources are available for use with other configs such as cluster_config.master_config.machine_type and cluster_config.worker_config.machine_type.",
+                    "Description": "The GCP zone where your data is stored and used (i.e. where the oligarch and the worker nodes will be created in). If region is set to 'global' (default) then zone is mandatory, otherwise GCP is able to make use of Auto Zone Placement to determine this automatically for you. Note: This setting additionally determines and restricts which computing resources are available for use with other configs such as cluster_config.oligarch_config.machine_type and cluster_config.worker_config.machine_type.",
                     "Computed": true
                   }
                 }
@@ -24999,10 +24999,10 @@
                 }
               }
             },
-            "master_config": {
+            "oligarch_config": {
               "Type": "List",
               "Optional": true,
-              "Description": "The Google Compute Engine config settings for the master/worker instances in a cluster.",
+              "Description": "The Google Compute Engine config settings for the oligarch/worker instances in a cluster.",
               "Computed": true,
               "MaxItems": 1,
               "IsBlock": true,
@@ -25061,7 +25061,7 @@
                         "num_local_ssds": {
                           "Type": "Int",
                           "Optional": true,
-                          "Description": "The amount of local SSD disks that will be attached to each master cluster node. Defaults to 0.",
+                          "Description": "The amount of local SSD disks that will be attached to each oligarch cluster node. Defaults to 0.",
                           "Computed": true
                         }
                       }
@@ -25070,12 +25070,12 @@
                   "image_uri": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The URI for the image to use for this master/worker",
+                    "Description": "The URI for the image to use for this oligarch/worker",
                     "Computed": true
                   },
                   "instance_names": {
                     "Type": "List",
-                    "Description": "List of master/worker instance names which have been assigned to the cluster.",
+                    "Description": "List of oligarch/worker instance names which have been assigned to the cluster.",
                     "Computed": true,
                     "ConfigImplicitMode": "Attr",
                     "Elem": {
@@ -25086,19 +25086,19 @@
                   "machine_type": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a Google Compute Engine machine type to create for the master/worker",
+                    "Description": "The name of a Google Compute Engine machine type to create for the oligarch/worker",
                     "Computed": true
                   },
                   "min_cpu_platform": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a minimum generation of CPU family for the master/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
+                    "Description": "The name of a minimum generation of CPU family for the oligarch/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
                     "Computed": true
                   },
                   "num_instances": {
                     "Type": "Int",
                     "Optional": true,
-                    "Description": "Specifies the number of master/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
+                    "Description": "Specifies the number of oligarch/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
                     "Computed": true
                   }
                 }
@@ -25217,7 +25217,7 @@
                         "kdc_db_key_uri": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "The Cloud Storage URI of a KMS encrypted file containing the master key of the KDC database."
+                          "Description": "The Cloud Storage URI of a KMS encrypted file containing the oligarch key of the KDC database."
                         },
                         "key_password_uri": {
                           "Type": "String",
@@ -25323,7 +25323,7 @@
             "worker_config": {
               "Type": "List",
               "Optional": true,
-              "Description": "The Google Compute Engine config settings for the master/worker instances in a cluster.",
+              "Description": "The Google Compute Engine config settings for the oligarch/worker instances in a cluster.",
               "Computed": true,
               "MaxItems": 1,
               "IsBlock": true,
@@ -25382,7 +25382,7 @@
                         "num_local_ssds": {
                           "Type": "Int",
                           "Optional": true,
-                          "Description": "The amount of local SSD disks that will be attached to each master cluster node. Defaults to 0.",
+                          "Description": "The amount of local SSD disks that will be attached to each oligarch cluster node. Defaults to 0.",
                           "Computed": true
                         }
                       }
@@ -25391,12 +25391,12 @@
                   "image_uri": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The URI for the image to use for this master/worker",
+                    "Description": "The URI for the image to use for this oligarch/worker",
                     "Computed": true
                   },
                   "instance_names": {
                     "Type": "List",
-                    "Description": "List of master/worker instance names which have been assigned to the cluster.",
+                    "Description": "List of oligarch/worker instance names which have been assigned to the cluster.",
                     "Computed": true,
                     "ConfigImplicitMode": "Attr",
                     "Elem": {
@@ -25407,19 +25407,19 @@
                   "machine_type": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a Google Compute Engine machine type to create for the master/worker",
+                    "Description": "The name of a Google Compute Engine machine type to create for the oligarch/worker",
                     "Computed": true
                   },
                   "min_cpu_platform": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a minimum generation of CPU family for the master/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
+                    "Description": "The name of a minimum generation of CPU family for the oligarch/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
                     "Computed": true
                   },
                   "num_instances": {
                     "Type": "Int",
                     "Optional": true,
-                    "Description": "Specifies the number of master/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
+                    "Description": "Specifies the number of oligarch/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
                     "Computed": true
                   }
                 }
@@ -28855,7 +28855,7 @@
                         "schema_type": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Specifies the output schema type. Only ANALYTICS is supported at this time.\n * ANALYTICS: Analytics schema defined by the FHIR community.\n  See https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md. Default value: \"ANALYTICS\" Possible values: [\"ANALYTICS\"]",
+                          "Description": "Specifies the output schema type. Only ANALYTICS is supported at this time.\n * ANALYTICS: Analytics schema defined by the FHIR community.\n  See https://github.com/FHIR/sql-on-fhir/blob/oligarch/sql-on-fhir.md. Default value: \"ANALYTICS\" Possible values: [\"ANALYTICS\"]",
                           "Default": {
                             "Type": "string",
                             "Value": "ANALYTICS"
@@ -37662,10 +37662,10 @@
           }
         }
       },
-      "master_instance_name": {
+      "oligarch_instance_name": {
         "Type": "String",
         "Optional": true,
-        "Description": "The name of the instance that will act as the master in the replication setup. Note, this requires the master to have binary_log_enabled set, as well as existing backups.",
+        "Description": "The name of the instance that will act as the oligarch in the replication setup. Note, this requires the oligarch to have binary_log_enabled set, as well as existing backups.",
         "Computed": true
       },
       "name": {
@@ -37715,12 +37715,12 @@
             "client_certificate": {
               "Type": "String",
               "Optional": true,
-              "Description": "PEM representation of the slave's x509 certificate."
+              "Description": "PEM representation of the politician's x509 certificate."
             },
             "client_key": {
               "Type": "String",
               "Optional": true,
-              "Description": "PEM representation of the slave's private key. The corresponding public key in encoded in the client_certificate."
+              "Description": "PEM representation of the politician's private key. The corresponding public key in encoded in the client_certificate."
             },
             "connect_retry_interval": {
               "Type": "Int",
@@ -37730,14 +37730,14 @@
             "dump_file_path": {
               "Type": "String",
               "Optional": true,
-              "Description": "Path to a SQL file in GCS from which slave instances are created. Format is gs://bucket/filename."
+              "Description": "Path to a SQL file in GCS from which politician instances are created. Format is gs://bucket/filename."
             },
             "failover_target": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "Specifies if the replica is the failover target. If the field is set to true the replica will be designated as a failover replica. If the master instance fails, the replica instance will be promoted as the new master instance."
+              "Description": "Specifies if the replica is the failover target. If the field is set to true the replica will be designated as a failover replica. If the oligarch instance fails, the replica instance will be promoted as the new oligarch instance."
             },
-            "master_heartbeat_period": {
+            "oligarch_heartbeat_period": {
               "Type": "Int",
               "Optional": true,
               "Description": "Time in ms between replication heartbeats."
@@ -37760,7 +37760,7 @@
             "verify_server_certificate": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "True if the master's common name value is checked during the SSL handshake."
+              "Description": "True if the oligarch's common name value is checked during the SSL handshake."
             }
           }
         }
@@ -42133,7 +42133,7 @@
             },
             "network_policy_config": {
               "Type": "List",
-              "Description": "Whether we should enable the network policy addon for the master. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
+              "Description": "Whether we should enable the network policy addon for the oligarch. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
               "Computed": true,
               "IsBlock": true,
               "ConfigImplicitMode": "ComputedBlock",
@@ -42332,7 +42332,7 @@
       },
       "endpoint": {
         "Type": "String",
-        "Description": "The IP address of this cluster's Kubernetes master.",
+        "Description": "The IP address of this cluster's Kubernetes oligarch.",
         "Computed": true
       },
       "initial_node_count": {
@@ -42398,7 +42398,7 @@
       "location": {
         "Type": "String",
         "Optional": true,
-        "Description": "The location (region or zone) in which the cluster master will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region, and with default node locations in those zones as well."
+        "Description": "The location (region or zone) in which the cluster oligarch will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster oligarch. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple oligarchs spread across zones in the region, and with default node locations in those zones as well."
       },
       "logging_service": {
         "Type": "String",
@@ -42461,9 +42461,9 @@
           }
         }
       },
-      "master_auth": {
+      "oligarch_auth": {
         "Type": "List",
-        "Description": "The authentication information for accessing the Kubernetes master. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
+        "Description": "The authentication information for accessing the Kubernetes oligarch. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
         "Computed": true,
         "IsBlock": true,
         "ConfigImplicitMode": "ComputedBlock",
@@ -42504,20 +42504,20 @@
             },
             "password": {
               "Type": "String",
-              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint.",
               "Computed": true
             },
             "username": {
               "Type": "String",
-              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. If not present basic auth will be disabled.",
+              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint. If not present basic auth will be disabled.",
               "Computed": true
             }
           }
         }
       },
-      "master_authorized_networks_config": {
+      "oligarch_authorized_networks_config": {
         "Type": "List",
-        "Description": "The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
+        "Description": "The desired configuration options for oligarch authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
         "Computed": true,
         "IsBlock": true,
         "ConfigImplicitMode": "ComputedBlock",
@@ -42526,7 +42526,7 @@
           "Info": {
             "cidr_blocks": {
               "Type": "Set",
-              "Description": "External networks that can access the Kubernetes cluster master through HTTPS.",
+              "Description": "External networks that can access the Kubernetes cluster oligarch through HTTPS.",
               "Computed": true,
               "IsBlock": true,
               "ConfigImplicitMode": "ComputedBlock",
@@ -42535,7 +42535,7 @@
                 "Info": {
                   "cidr_block": {
                     "Type": "String",
-                    "Description": "External network that can access Kubernetes master through HTTPS. Must be specified in CIDR notation.",
+                    "Description": "External network that can access Kubernetes oligarch through HTTPS. Must be specified in CIDR notation.",
                     "Computed": true
                   },
                   "display_name": {
@@ -42549,14 +42549,14 @@
           }
         }
       },
-      "master_version": {
+      "oligarch_version": {
         "Type": "String",
-        "Description": "The current version of the master in the cluster. This may be different than the min_master_version set in the config if the master has been updated by GKE.",
+        "Description": "The current version of the oligarch in the cluster. This may be different than the min_oligarch_version set in the config if the oligarch has been updated by GKE.",
         "Computed": true
       },
-      "min_master_version": {
+      "min_oligarch_version": {
         "Type": "String",
-        "Description": "The minimum version of the master. GKE will auto-update the master to new versions, so this does not guarantee the current master version--use the read-only master_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version).",
+        "Description": "The minimum version of the oligarch. GKE will auto-update the oligarch to new versions, so this does not guarantee the current oligarch version--use the read-only oligarch_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version).",
         "Computed": true
       },
       "monitoring_service": {
@@ -43089,7 +43089,7 @@
       },
       "node_version": {
         "Type": "String",
-        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_master_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
+        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_oligarch_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
         "Computed": true
       },
       "operation": {
@@ -43124,7 +43124,7 @@
           "Info": {
             "enable_private_endpoint": {
               "Type": "Bool",
-              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the master's private endpoint via private networking.",
+              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the oligarch's private endpoint via private networking.",
               "Computed": true
             },
             "enable_private_nodes": {
@@ -43132,9 +43132,9 @@
               "Description": "When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable_private_nodes is true.",
               "Computed": true
             },
-            "master_global_access_config": {
+            "oligarch_global_access_config": {
               "Type": "List",
-              "Description": "Controls cluster master global access settings.",
+              "Description": "Controls cluster oligarch global access settings.",
               "Computed": true,
               "IsBlock": true,
               "ConfigImplicitMode": "ComputedBlock",
@@ -43143,15 +43143,15 @@
                 "Info": {
                   "enabled": {
                     "Type": "Bool",
-                    "Description": "Whether the cluster master is accessible globally or not.",
+                    "Description": "Whether the cluster oligarch is accessible globally or not.",
                     "Computed": true
                   }
                 }
               }
             },
-            "master_ipv4_cidr_block": {
+            "oligarch_ipv4_cidr_block": {
               "Type": "String",
-              "Description": "The IP range in CIDR notation to use for the hosted master network. This range will be used for assigning private IP addresses to the cluster master(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true.",
+              "Description": "The IP range in CIDR notation to use for the hosted oligarch network. This range will be used for assigning private IP addresses to the cluster oligarch(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true.",
               "Computed": true
             },
             "peering_name": {
@@ -43161,12 +43161,12 @@
             },
             "private_endpoint": {
               "Type": "String",
-              "Description": "The internal IP address of this cluster's master endpoint.",
+              "Description": "The internal IP address of this cluster's oligarch endpoint.",
               "Computed": true
             },
             "public_endpoint": {
               "Type": "String",
-              "Description": "The external IP address of this cluster's master endpoint.",
+              "Description": "The external IP address of this cluster's oligarch endpoint.",
               "Computed": true
             }
           }
@@ -43180,7 +43180,7 @@
       "region": {
         "Type": "String",
         "Optional": true,
-        "Description": "The region in which the cluster master will be created. Zone and region have been removed in favor of location."
+        "Description": "The region in which the cluster oligarch will be created. Zone and region have been removed in favor of location."
       },
       "release_channel": {
         "Type": "List",
@@ -43303,7 +43303,7 @@
       "zone": {
         "Type": "String",
         "Optional": true,
-        "Description": "The zone in which the cluster master will be created. Zone and region have been removed in favor of location."
+        "Description": "The zone in which the cluster oligarch will be created. Zone and region have been removed in favor of location."
       }
     },
     "google_container_engine_versions": {
@@ -43311,7 +43311,7 @@
         "Type": "String",
         "Computed": true
       },
-      "latest_master_version": {
+      "latest_oligarch_version": {
         "Type": "String",
         "Computed": true
       },
@@ -43342,7 +43342,7 @@
           "ElementsType": "String"
         }
       },
-      "valid_master_versions": {
+      "valid_oligarch_versions": {
         "Type": "List",
         "Computed": true,
         "ConfigImplicitMode": "Attr",

--- a/terraform/model/providers/google.json
+++ b/terraform/model/providers/google.json
@@ -5207,7 +5207,7 @@
       "template": {
         "Type": "List",
         "Optional": true,
-        "Description": "template holds the latest specification for the Revision to\nbe stamped out. The template references the container image, and may also\ninclude labels and annotations that should be attached to the Revision.\nTo correlate a Revision, and/or to force a Revision to be created when the\nspec doesn't otherwise change, a nonce label may be provided in the\ntemplate metadata. For more details, see:\nhttps://github.com/knative/serving/blob/master/docs/client-conventions.md#associate-modifications-with-revisions\n\nCloud Run does not currently support referencing a build that is\nresponsible for materializing the container image from source.",
+        "Description": "template holds the latest specification for the Revision to\nbe stamped out. The template references the container image, and may also\ninclude labels and annotations that should be attached to the Revision.\nTo correlate a Revision, and/or to force a Revision to be created when the\nspec doesn't otherwise change, a nonce label may be provided in the\ntemplate metadata. For more details, see:\nhttps://github.com/knative/serving/blob/oligarch/docs/client-conventions.md#associate-modifications-with-revisions\n\nCloud Run does not currently support referencing a build that is\nresponsible for materializing the container image from source.",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -5301,7 +5301,7 @@
                   "containers": {
                     "Type": "List",
                     "Optional": true,
-                    "Description": "Container defines the unit of execution for this Revision.\nIn the context of a Revision, we disallow a number of the fields of\nthis Container, including: name, ports, and volumeMounts.\nThe runtime contract is documented here:\nhttps://github.com/knative/serving/blob/master/docs/runtime-contract.md",
+                    "Description": "Container defines the unit of execution for this Revision.\nIn the context of a Revision, we disallow a number of the fields of\nthis Container, including: name, ports, and volumeMounts.\nThe runtime contract is documented here:\nhttps://github.com/knative/serving/blob/oligarch/docs/runtime-contract.md",
                     "Computed": true,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -5459,7 +5459,7 @@
                               "limits": {
                                 "Type": "Map",
                                 "Optional": true,
-                                "Description": "Limits describes the maximum amount of compute resources allowed.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
+                                "Description": "Limits describes the maximum amount of compute resources allowed.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/oligarch/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
                                 "Computed": true,
                                 "ConfigImplicitMode": "Attr",
                                 "Elem": {
@@ -5470,7 +5470,7 @@
                               "requests": {
                                 "Type": "Map",
                                 "Optional": true,
-                                "Description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is\nexplicitly specified, otherwise to an implementation-defined value.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
+                                "Description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is\nexplicitly specified, otherwise to an implementation-defined value.\nThe values of the map is string form of the 'quantity' k8s type:\nhttps://github.com/kubernetes/kubernetes/blob/oligarch/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go",
                                 "ConfigImplicitMode": "Attr",
                                 "Elem": {
                                   "Type": "SchemaElements",
@@ -6972,10 +6972,10 @@
                       "Value": "true"
                     }
                   },
-                  "master_ipv4_cidr_block": {
+                  "oligarch_ipv4_cidr_block": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The IP range in CIDR notation to use for the hosted master network. This range is used for assigning internal IP addresses to the cluster master or set of masters and to the internal load balancer virtual IP. This range must not overlap with any other ranges in use within the cluster's network. If left blank, the default value of '172.16.0.0/28' is used.",
+                    "Description": "The IP range in CIDR notation to use for the hosted oligarch network. This range is used for assigning internal IP addresses to the cluster oligarch or set of oligarchs and to the internal load balancer virtual IP. This range must not overlap with any other ranges in use within the cluster's network. If left blank, the default value of '172.16.0.0/28' is used.",
                     "Default": {
                       "Type": "string",
                       "Value": "172.16.0.0/28"
@@ -6984,7 +6984,7 @@
                   "web_server_ipv4_cidr_block": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The CIDR block from which IP range for web server will be reserved. Needs to be disjoint from master_ipv4_cidr_block and cloud_sql_ipv4_cidr_block.",
+                    "Description": "The CIDR block from which IP range for web server will be reserved. Needs to be disjoint from oligarch_ipv4_cidr_block and cloud_sql_ipv4_cidr_block.",
                     "Computed": true
                   }
                 }
@@ -20028,7 +20028,7 @@
             "network_policy_config": {
               "Type": "List",
               "Optional": true,
-              "Description": "Whether we should enable the network policy addon for the master. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
+              "Description": "Whether we should enable the network policy addon for the oligarch. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
               "Computed": true,
               "MaxItems": 1,
               "IsBlock": true,
@@ -20241,7 +20241,7 @@
       },
       "endpoint": {
         "Type": "String",
-        "Description": "The IP address of this cluster's Kubernetes master.",
+        "Description": "The IP address of this cluster's Kubernetes oligarch.",
         "Computed": true
       },
       "initial_node_count": {
@@ -20335,7 +20335,7 @@
       "location": {
         "Type": "String",
         "Optional": true,
-        "Description": "The location (region or zone) in which the cluster master will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region, and with default node locations in those zones as well.",
+        "Description": "The location (region or zone) in which the cluster oligarch will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster oligarch. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple oligarchs spread across zones in the region, and with default node locations in those zones as well.",
         "Computed": true
       },
       "logging_service": {
@@ -20403,10 +20403,10 @@
           }
         }
       },
-      "master_auth": {
+      "oligarch_auth": {
         "Type": "List",
         "Optional": true,
-        "Description": "The authentication information for accessing the Kubernetes master. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
+        "Description": "The authentication information for accessing the Kubernetes oligarch. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
         "Computed": true,
         "MaxItems": 1,
         "IsBlock": true,
@@ -20451,20 +20451,20 @@
             "password": {
               "Type": "String",
               "Optional": true,
-              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint."
+              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint."
             },
             "username": {
               "Type": "String",
               "Optional": true,
-              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. If not present basic auth will be disabled."
+              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint. If not present basic auth will be disabled."
             }
           }
         }
       },
-      "master_authorized_networks_config": {
+      "oligarch_authorized_networks_config": {
         "Type": "List",
         "Optional": true,
-        "Description": "The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
+        "Description": "The desired configuration options for oligarch authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -20474,7 +20474,7 @@
             "cidr_blocks": {
               "Type": "Set",
               "Optional": true,
-              "Description": "External networks that can access the Kubernetes cluster master through HTTPS.",
+              "Description": "External networks that can access the Kubernetes cluster oligarch through HTTPS.",
               "IsBlock": true,
               "ConfigImplicitMode": "Block",
               "Elem": {
@@ -20483,7 +20483,7 @@
                   "cidr_block": {
                     "Type": "String",
                     "Required": true,
-                    "Description": "External network that can access Kubernetes master through HTTPS. Must be specified in CIDR notation."
+                    "Description": "External network that can access Kubernetes oligarch through HTTPS. Must be specified in CIDR notation."
                   },
                   "display_name": {
                     "Type": "String",
@@ -20496,15 +20496,15 @@
           }
         }
       },
-      "master_version": {
+      "oligarch_version": {
         "Type": "String",
-        "Description": "The current version of the master in the cluster. This may be different than the min_master_version set in the config if the master has been updated by GKE.",
+        "Description": "The current version of the oligarch in the cluster. This may be different than the min_oligarch_version set in the config if the oligarch has been updated by GKE.",
         "Computed": true
       },
-      "min_master_version": {
+      "min_oligarch_version": {
         "Type": "String",
         "Optional": true,
-        "Description": "The minimum version of the master. GKE will auto-update the master to new versions, so this does not guarantee the current master version--use the read-only master_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version)."
+        "Description": "The minimum version of the oligarch. GKE will auto-update the oligarch to new versions, so this does not guarantee the current oligarch version--use the read-only oligarch_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version)."
       },
       "monitoring_service": {
         "Type": "String",
@@ -21119,7 +21119,7 @@
       "node_version": {
         "Type": "String",
         "Optional": true,
-        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_master_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
+        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_oligarch_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
         "Computed": true
       },
       "operation": {
@@ -21160,17 +21160,17 @@
             "enable_private_endpoint": {
               "Type": "Bool",
               "Required": true,
-              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the master's private endpoint via private networking."
+              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the oligarch's private endpoint via private networking."
             },
             "enable_private_nodes": {
               "Type": "Bool",
               "Optional": true,
               "Description": "When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable_private_nodes is true."
             },
-            "master_ipv4_cidr_block": {
+            "oligarch_ipv4_cidr_block": {
               "Type": "String",
               "Optional": true,
-              "Description": "The IP range in CIDR notation to use for the hosted master network. This range will be used for assigning private IP addresses to the cluster master(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true."
+              "Description": "The IP range in CIDR notation to use for the hosted oligarch network. This range will be used for assigning private IP addresses to the cluster oligarch(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true."
             },
             "peering_name": {
               "Type": "String",
@@ -21179,12 +21179,12 @@
             },
             "private_endpoint": {
               "Type": "String",
-              "Description": "The internal IP address of this cluster's master endpoint.",
+              "Description": "The internal IP address of this cluster's oligarch endpoint.",
               "Computed": true
             },
             "public_endpoint": {
               "Type": "String",
-              "Description": "The external IP address of this cluster's master endpoint.",
+              "Description": "The external IP address of this cluster's oligarch endpoint.",
               "Computed": true
             }
           }
@@ -21199,7 +21199,7 @@
       "region": {
         "Type": "String",
         "Optional": true,
-        "Description": "The region in which the cluster master will be created. Zone and region have been removed in favor of location.",
+        "Description": "The region in which the cluster oligarch will be created. Zone and region have been removed in favor of location.",
         "Computed": true,
         "Removed": "Use location instead"
       },
@@ -21315,7 +21315,7 @@
       "zone": {
         "Type": "String",
         "Optional": true,
-        "Description": "The zone in which the cluster master will be created. Zone and region have been removed in favor of location.",
+        "Description": "The zone in which the cluster oligarch will be created. Zone and region have been removed in favor of location.",
         "Computed": true,
         "Removed": "Use location instead"
       }
@@ -22698,7 +22698,7 @@
                   "zone": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The GCP zone where your data is stored and used (i.e. where the master and the worker nodes will be created in). If region is set to 'global' (default) then zone is mandatory, otherwise GCP is able to make use of Auto Zone Placement to determine this automatically for you. Note: This setting additionally determines and restricts which computing resources are available for use with other configs such as cluster_config.master_config.machine_type and cluster_config.worker_config.machine_type.",
+                    "Description": "The GCP zone where your data is stored and used (i.e. where the oligarch and the worker nodes will be created in). If region is set to 'global' (default) then zone is mandatory, otherwise GCP is able to make use of Auto Zone Placement to determine this automatically for you. Note: This setting additionally determines and restricts which computing resources are available for use with other configs such as cluster_config.oligarch_config.machine_type and cluster_config.worker_config.machine_type.",
                     "Computed": true
                   }
                 }
@@ -22730,10 +22730,10 @@
                 }
               }
             },
-            "master_config": {
+            "oligarch_config": {
               "Type": "List",
               "Optional": true,
-              "Description": "The Google Compute Engine config settings for the master/worker instances in a cluster.",
+              "Description": "The Google Compute Engine config settings for the oligarch/worker instances in a cluster.",
               "Computed": true,
               "MaxItems": 1,
               "IsBlock": true,
@@ -22792,7 +22792,7 @@
                         "num_local_ssds": {
                           "Type": "Int",
                           "Optional": true,
-                          "Description": "The amount of local SSD disks that will be attached to each master cluster node. Defaults to 0.",
+                          "Description": "The amount of local SSD disks that will be attached to each oligarch cluster node. Defaults to 0.",
                           "Computed": true
                         }
                       }
@@ -22801,12 +22801,12 @@
                   "image_uri": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The URI for the image to use for this master/worker",
+                    "Description": "The URI for the image to use for this oligarch/worker",
                     "Computed": true
                   },
                   "instance_names": {
                     "Type": "List",
-                    "Description": "List of master/worker instance names which have been assigned to the cluster.",
+                    "Description": "List of oligarch/worker instance names which have been assigned to the cluster.",
                     "Computed": true,
                     "ConfigImplicitMode": "Attr",
                     "Elem": {
@@ -22817,19 +22817,19 @@
                   "machine_type": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a Google Compute Engine machine type to create for the master/worker",
+                    "Description": "The name of a Google Compute Engine machine type to create for the oligarch/worker",
                     "Computed": true
                   },
                   "min_cpu_platform": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a minimum generation of CPU family for the master/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
+                    "Description": "The name of a minimum generation of CPU family for the oligarch/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
                     "Computed": true
                   },
                   "num_instances": {
                     "Type": "Int",
                     "Optional": true,
-                    "Description": "Specifies the number of master/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
+                    "Description": "Specifies the number of oligarch/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
                     "Computed": true
                   }
                 }
@@ -22948,7 +22948,7 @@
                         "kdc_db_key_uri": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "The Cloud Storage URI of a KMS encrypted file containing the master key of the KDC database."
+                          "Description": "The Cloud Storage URI of a KMS encrypted file containing the oligarch key of the KDC database."
                         },
                         "key_password_uri": {
                           "Type": "String",
@@ -23054,7 +23054,7 @@
             "worker_config": {
               "Type": "List",
               "Optional": true,
-              "Description": "The Google Compute Engine config settings for the master/worker instances in a cluster.",
+              "Description": "The Google Compute Engine config settings for the oligarch/worker instances in a cluster.",
               "Computed": true,
               "MaxItems": 1,
               "IsBlock": true,
@@ -23113,7 +23113,7 @@
                         "num_local_ssds": {
                           "Type": "Int",
                           "Optional": true,
-                          "Description": "The amount of local SSD disks that will be attached to each master cluster node. Defaults to 0.",
+                          "Description": "The amount of local SSD disks that will be attached to each oligarch cluster node. Defaults to 0.",
                           "Computed": true
                         }
                       }
@@ -23122,12 +23122,12 @@
                   "image_uri": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The URI for the image to use for this master/worker",
+                    "Description": "The URI for the image to use for this oligarch/worker",
                     "Computed": true
                   },
                   "instance_names": {
                     "Type": "List",
-                    "Description": "List of master/worker instance names which have been assigned to the cluster.",
+                    "Description": "List of oligarch/worker instance names which have been assigned to the cluster.",
                     "Computed": true,
                     "ConfigImplicitMode": "Attr",
                     "Elem": {
@@ -23138,19 +23138,19 @@
                   "machine_type": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a Google Compute Engine machine type to create for the master/worker",
+                    "Description": "The name of a Google Compute Engine machine type to create for the oligarch/worker",
                     "Computed": true
                   },
                   "min_cpu_platform": {
                     "Type": "String",
                     "Optional": true,
-                    "Description": "The name of a minimum generation of CPU family for the master/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
+                    "Description": "The name of a minimum generation of CPU family for the oligarch/worker. If not specified, GCP will default to a predetermined computed value for each zone.",
                     "Computed": true
                   },
                   "num_instances": {
                     "Type": "Int",
                     "Optional": true,
-                    "Description": "Specifies the number of master/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
+                    "Description": "Specifies the number of oligarch/worker nodes to create. If not specified, GCP will default to a predetermined computed value.",
                     "Computed": true
                   }
                 }
@@ -26081,7 +26081,7 @@
                         "schema_type": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Specifies the output schema type. Only ANALYTICS is supported at this time.\n * ANALYTICS: Analytics schema defined by the FHIR community.\n  See https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md. Default value: \"ANALYTICS\" Possible values: [\"ANALYTICS\"]",
+                          "Description": "Specifies the output schema type. Only ANALYTICS is supported at this time.\n * ANALYTICS: Analytics schema defined by the FHIR community.\n  See https://github.com/FHIR/sql-on-fhir/blob/oligarch/sql-on-fhir.md. Default value: \"ANALYTICS\" Possible values: [\"ANALYTICS\"]",
                           "Default": {
                             "Type": "string",
                             "Value": "ANALYTICS"
@@ -33885,10 +33885,10 @@
           }
         }
       },
-      "master_instance_name": {
+      "oligarch_instance_name": {
         "Type": "String",
         "Optional": true,
-        "Description": "The name of the instance that will act as the master in the replication setup. Note, this requires the master to have binary_log_enabled set, as well as existing backups.",
+        "Description": "The name of the instance that will act as the oligarch in the replication setup. Note, this requires the oligarch to have binary_log_enabled set, as well as existing backups.",
         "Computed": true
       },
       "name": {
@@ -33938,12 +33938,12 @@
             "client_certificate": {
               "Type": "String",
               "Optional": true,
-              "Description": "PEM representation of the slave's x509 certificate."
+              "Description": "PEM representation of the politician's x509 certificate."
             },
             "client_key": {
               "Type": "String",
               "Optional": true,
-              "Description": "PEM representation of the slave's private key. The corresponding public key in encoded in the client_certificate."
+              "Description": "PEM representation of the politician's private key. The corresponding public key in encoded in the client_certificate."
             },
             "connect_retry_interval": {
               "Type": "Int",
@@ -33953,14 +33953,14 @@
             "dump_file_path": {
               "Type": "String",
               "Optional": true,
-              "Description": "Path to a SQL file in GCS from which slave instances are created. Format is gs://bucket/filename."
+              "Description": "Path to a SQL file in GCS from which politician instances are created. Format is gs://bucket/filename."
             },
             "failover_target": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "Specifies if the replica is the failover target. If the field is set to true the replica will be designated as a failover replica. If the master instance fails, the replica instance will be promoted as the new master instance."
+              "Description": "Specifies if the replica is the failover target. If the field is set to true the replica will be designated as a failover replica. If the oligarch instance fails, the replica instance will be promoted as the new oligarch instance."
             },
-            "master_heartbeat_period": {
+            "oligarch_heartbeat_period": {
               "Type": "Int",
               "Optional": true,
               "Description": "Time in ms between replication heartbeats."
@@ -33983,7 +33983,7 @@
             "verify_server_certificate": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "True if the master's common name value is checked during the SSL handshake."
+              "Description": "True if the oligarch's common name value is checked during the SSL handshake."
             }
           }
         }
@@ -38036,7 +38036,7 @@
             },
             "network_policy_config": {
               "Type": "List",
-              "Description": "Whether we should enable the network policy addon for the master. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
+              "Description": "Whether we should enable the network policy addon for the oligarch. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.",
               "Computed": true,
               "IsBlock": true,
               "ConfigImplicitMode": "ComputedBlock",
@@ -38210,7 +38210,7 @@
       },
       "endpoint": {
         "Type": "String",
-        "Description": "The IP address of this cluster's Kubernetes master.",
+        "Description": "The IP address of this cluster's Kubernetes oligarch.",
         "Computed": true
       },
       "initial_node_count": {
@@ -38276,7 +38276,7 @@
       "location": {
         "Type": "String",
         "Optional": true,
-        "Description": "The location (region or zone) in which the cluster master will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region, and with default node locations in those zones as well."
+        "Description": "The location (region or zone) in which the cluster oligarch will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster oligarch. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple oligarchs spread across zones in the region, and with default node locations in those zones as well."
       },
       "logging_service": {
         "Type": "String",
@@ -38339,9 +38339,9 @@
           }
         }
       },
-      "master_auth": {
+      "oligarch_auth": {
         "Type": "List",
-        "Description": "The authentication information for accessing the Kubernetes master. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
+        "Description": "The authentication information for accessing the Kubernetes oligarch. Some values in this block are only returned by the API if your service account has permission to get credentials for your GKE cluster. If you see an unexpected diff removing a username/password or unsetting your client cert, ensure you have the container.clusters.getCredentials permission.",
         "Computed": true,
         "IsBlock": true,
         "ConfigImplicitMode": "ComputedBlock",
@@ -38382,20 +38382,20 @@
             },
             "password": {
               "Type": "String",
-              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+              "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint.",
               "Computed": true
             },
             "username": {
               "Type": "String",
-              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. If not present basic auth will be disabled.",
+              "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint. If not present basic auth will be disabled.",
               "Computed": true
             }
           }
         }
       },
-      "master_authorized_networks_config": {
+      "oligarch_authorized_networks_config": {
         "Type": "List",
-        "Description": "The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
+        "Description": "The desired configuration options for oligarch authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).",
         "Computed": true,
         "IsBlock": true,
         "ConfigImplicitMode": "ComputedBlock",
@@ -38404,7 +38404,7 @@
           "Info": {
             "cidr_blocks": {
               "Type": "Set",
-              "Description": "External networks that can access the Kubernetes cluster master through HTTPS.",
+              "Description": "External networks that can access the Kubernetes cluster oligarch through HTTPS.",
               "Computed": true,
               "IsBlock": true,
               "ConfigImplicitMode": "ComputedBlock",
@@ -38413,7 +38413,7 @@
                 "Info": {
                   "cidr_block": {
                     "Type": "String",
-                    "Description": "External network that can access Kubernetes master through HTTPS. Must be specified in CIDR notation.",
+                    "Description": "External network that can access Kubernetes oligarch through HTTPS. Must be specified in CIDR notation.",
                     "Computed": true
                   },
                   "display_name": {
@@ -38427,14 +38427,14 @@
           }
         }
       },
-      "master_version": {
+      "oligarch_version": {
         "Type": "String",
-        "Description": "The current version of the master in the cluster. This may be different than the min_master_version set in the config if the master has been updated by GKE.",
+        "Description": "The current version of the oligarch in the cluster. This may be different than the min_oligarch_version set in the config if the oligarch has been updated by GKE.",
         "Computed": true
       },
-      "min_master_version": {
+      "min_oligarch_version": {
         "Type": "String",
-        "Description": "The minimum version of the master. GKE will auto-update the master to new versions, so this does not guarantee the current master version--use the read-only master_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version).",
+        "Description": "The minimum version of the oligarch. GKE will auto-update the oligarch to new versions, so this does not guarantee the current oligarch version--use the read-only oligarch_version field to obtain that. If unset, the cluster's version will be set by GKE to the version of the most recent official release (which is not necessarily the latest version).",
         "Computed": true
       },
       "monitoring_service": {
@@ -38954,7 +38954,7 @@
       },
       "node_version": {
         "Type": "String",
-        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_master_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
+        "Description": "The Kubernetes version on the nodes. Must either be unset or set to the same value as min_oligarch_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.",
         "Computed": true
       },
       "operation": {
@@ -38989,7 +38989,7 @@
           "Info": {
             "enable_private_endpoint": {
               "Type": "Bool",
-              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the master's private endpoint via private networking.",
+              "Description": "Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the oligarch's private endpoint via private networking.",
               "Computed": true
             },
             "enable_private_nodes": {
@@ -38997,9 +38997,9 @@
               "Description": "When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable_private_nodes is true.",
               "Computed": true
             },
-            "master_ipv4_cidr_block": {
+            "oligarch_ipv4_cidr_block": {
               "Type": "String",
-              "Description": "The IP range in CIDR notation to use for the hosted master network. This range will be used for assigning private IP addresses to the cluster master(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true.",
+              "Description": "The IP range in CIDR notation to use for the hosted oligarch network. This range will be used for assigning private IP addresses to the cluster oligarch(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true.",
               "Computed": true
             },
             "peering_name": {
@@ -39009,12 +39009,12 @@
             },
             "private_endpoint": {
               "Type": "String",
-              "Description": "The internal IP address of this cluster's master endpoint.",
+              "Description": "The internal IP address of this cluster's oligarch endpoint.",
               "Computed": true
             },
             "public_endpoint": {
               "Type": "String",
-              "Description": "The external IP address of this cluster's master endpoint.",
+              "Description": "The external IP address of this cluster's oligarch endpoint.",
               "Computed": true
             }
           }
@@ -39028,7 +39028,7 @@
       "region": {
         "Type": "String",
         "Optional": true,
-        "Description": "The region in which the cluster master will be created. Zone and region have been removed in favor of location."
+        "Description": "The region in which the cluster oligarch will be created. Zone and region have been removed in favor of location."
       },
       "remove_default_node_pool": {
         "Type": "Bool",
@@ -39129,7 +39129,7 @@
       "zone": {
         "Type": "String",
         "Optional": true,
-        "Description": "The zone in which the cluster master will be created. Zone and region have been removed in favor of location."
+        "Description": "The zone in which the cluster oligarch will be created. Zone and region have been removed in favor of location."
       }
     },
     "google_container_engine_versions": {
@@ -39137,7 +39137,7 @@
         "Type": "String",
         "Computed": true
       },
-      "latest_master_version": {
+      "latest_oligarch_version": {
         "Type": "String",
         "Computed": true
       },
@@ -39159,7 +39159,7 @@
         "Computed": true,
         "Removed": "Use location instead"
       },
-      "valid_master_versions": {
+      "valid_oligarch_versions": {
         "Type": "List",
         "Computed": true,
         "ConfigImplicitMode": "Attr",

--- a/terraform/model/providers/helm.json
+++ b/terraform/model/providers/helm.json
@@ -107,7 +107,7 @@
           "host": {
             "Type": "String",
             "Optional": true,
-            "Description": "The hostname (in form of URI) of Kubernetes master.",
+            "Description": "The hostname (in form of URI) of Kubernetes oligarch.",
             "DefaultFunc": "ENV(KUBE_HOST)"
           },
           "insecure": {
@@ -125,7 +125,7 @@
           "password": {
             "Type": "String",
             "Optional": true,
-            "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+            "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint.",
             "DefaultFunc": "ENV(KUBE_PASSWORD)"
           },
           "token": {
@@ -137,7 +137,7 @@
           "username": {
             "Type": "String",
             "Optional": true,
-            "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+            "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint.",
             "DefaultFunc": "ENV(KUBE_USER)"
           }
         }

--- a/terraform/model/providers/huaweicloud.json
+++ b/terraform/model/providers/huaweicloud.json
@@ -3575,7 +3575,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Computed": true,
         "ConfigImplicitMode": "Attr",
@@ -6447,23 +6447,23 @@
         "Optional": true,
         "Computed": true
       },
-      "master_node_ip": {
+      "oligarch_node_ip": {
         "Type": "String",
         "Computed": true
       },
-      "master_node_num": {
+      "oligarch_node_num": {
         "Type": "Int",
         "Required": true
       },
-      "master_node_product_id": {
+      "oligarch_node_product_id": {
         "Type": "String",
         "Computed": true
       },
-      "master_node_size": {
+      "oligarch_node_size": {
         "Type": "String",
         "Required": true
       },
-      "master_node_spec_id": {
+      "oligarch_node_spec_id": {
         "Type": "String",
         "Computed": true
       },
@@ -6496,7 +6496,7 @@
         "Type": "String",
         "Computed": true
       },
-      "slave_security_groups_id": {
+      "politician_security_groups_id": {
         "Type": "String",
         "Computed": true
       },

--- a/terraform/model/providers/ksyun.json
+++ b/terraform/model/providers/ksyun.json
@@ -738,12 +738,12 @@
               "Optional": true,
               "Computed": true
             },
-            "master_availability_zone": {
+            "oligarch_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
             },
-            "master_user_name": {
+            "oligarch_user_name": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -860,7 +860,7 @@
               "Optional": true,
               "Computed": true
             },
-            "slave_availability_zone": {
+            "politician_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -888,11 +888,11 @@
           }
         }
       },
-      "master_user_name": {
+      "oligarch_user_name": {
         "Type": "String",
         "Required": true
       },
-      "master_user_password": {
+      "oligarch_user_password": {
         "Type": "String",
         "Required": true
       },
@@ -1154,12 +1154,12 @@
               "Optional": true,
               "Computed": true
             },
-            "master_availability_zone": {
+            "oligarch_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
             },
-            "master_user_name": {
+            "oligarch_user_name": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -1276,7 +1276,7 @@
               "Optional": true,
               "Computed": true
             },
-            "slave_availability_zone": {
+            "politician_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -2425,11 +2425,11 @@
         "Type": "Int",
         "Computed": true
       },
-      "slave_num": {
+      "politician_num": {
         "Type": "Int",
         "Required": true
       },
-      "slave_vip": {
+      "politician_vip": {
         "Type": "String",
         "Computed": true
       },
@@ -2702,11 +2702,11 @@
         "Required": true,
         "Description": "db engine version only support 2008r2,2012,2016"
       },
-      "master_user_name": {
+      "oligarch_user_name": {
         "Type": "String",
         "Required": true
       },
-      "master_user_password": {
+      "oligarch_user_password": {
         "Type": "String",
         "Required": true
       },
@@ -2906,12 +2906,12 @@
               "Optional": true,
               "Computed": true
             },
-            "master_availability_zone": {
+            "oligarch_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
             },
-            "master_user_name": {
+            "oligarch_user_name": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -3028,7 +3028,7 @@
               "Optional": true,
               "Computed": true
             },
-            "slave_availability_zone": {
+            "politician_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -4276,12 +4276,12 @@
               "Optional": true,
               "Computed": true
             },
-            "master_availability_zone": {
+            "oligarch_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
             },
-            "master_user_name": {
+            "oligarch_user_name": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -4398,7 +4398,7 @@
               "Optional": true,
               "Computed": true
             },
-            "slave_availability_zone": {
+            "politician_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -6036,12 +6036,12 @@
               "Optional": true,
               "Computed": true
             },
-            "master_availability_zone": {
+            "oligarch_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true
             },
-            "master_user_name": {
+            "oligarch_user_name": {
               "Type": "String",
               "Optional": true,
               "Computed": true
@@ -6158,7 +6158,7 @@
               "Optional": true,
               "Computed": true
             },
-            "slave_availability_zone": {
+            "politician_availability_zone": {
               "Type": "String",
               "Optional": true,
               "Computed": true

--- a/terraform/model/providers/kubernetes.json
+++ b/terraform/model/providers/kubernetes.json
@@ -85,7 +85,7 @@
     "host": {
       "Type": "String",
       "Optional": true,
-      "Description": "The hostname (in form of URI) of Kubernetes master.",
+      "Description": "The hostname (in form of URI) of Kubernetes oligarch.",
       "DefaultFunc": "ENV(KUBE_HOST)"
     },
     "insecure": {
@@ -103,7 +103,7 @@
     "password": {
       "Type": "String",
       "Optional": true,
-      "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+      "Description": "The password to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint.",
       "DefaultFunc": "ENV(KUBE_PASSWORD)"
     },
     "token": {
@@ -115,7 +115,7 @@
     "username": {
       "Type": "String",
       "Optional": true,
-      "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+      "Description": "The username to use for HTTP basic authentication when accessing the Kubernetes oligarch endpoint.",
       "DefaultFunc": "ENV(KUBE_USER)"
     }
   },
@@ -124,7 +124,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard api_service's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard api_service's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -144,7 +144,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.0.name"
               ]
@@ -175,7 +175,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this api_service that can be used by clients to determine when api_service has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this api_service that can be used by clients to determine when api_service has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -194,7 +194,7 @@
       "spec": {
         "Type": "List",
         "Required": true,
-        "Description": "Spec contains information for locating and communicating with a server. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+        "Description": "Spec contains information for locating and communicating with a server. https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -275,7 +275,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard clusterRole's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard clusterRole's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -315,7 +315,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this clusterRole that can be used by clients to determine when clusterRole has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this clusterRole that can be used by clients to determine when clusterRole has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -400,7 +400,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard clusterRoleBinding's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard clusterRoleBinding's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -440,7 +440,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this clusterRoleBinding that can be used by clients to determine when clusterRoleBinding has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this clusterRoleBinding that can be used by clients to determine when clusterRoleBinding has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -537,7 +537,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard config map's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard config map's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -557,7 +557,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -597,7 +597,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this config map that can be used by clients to determine when config map has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this config map that can be used by clients to determine when config map has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -621,7 +621,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard cronjob's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard cronjob's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -641,7 +641,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -681,7 +681,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this cronjob that can be used by clients to determine when cronjob has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this cronjob that can be used by clients to determine when cronjob has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -738,7 +738,7 @@
                   "metadata": {
                     "Type": "List",
                     "Required": true,
-                    "Description": "Standard jobTemplateSpec's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "Description": "Standard jobTemplateSpec's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                     "MaxItems": 1,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -758,7 +758,7 @@
                         "generate_name": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                           "ConflictsWith": [
                             "metadata.0.name"
                           ]
@@ -789,7 +789,7 @@
                         },
                         "resource_version": {
                           "Type": "String",
-                          "Description": "An opaque value that represents the internal version of this jobTemplateSpec that can be used by clients to determine when jobTemplateSpec has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "Description": "An opaque value that represents the internal version of this jobTemplateSpec that can be used by clients to determine when jobTemplateSpec has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                           "Computed": true
                         },
                         "self_link": {
@@ -912,7 +912,7 @@
                               "metadata": {
                                 "Type": "List",
                                 "Required": true,
-                                "Description": "Standard job's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                "Description": "Standard job's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                                 "MaxItems": 1,
                                 "IsBlock": true,
                                 "ConfigImplicitMode": "Block",
@@ -932,7 +932,7 @@
                                     "generate_name": {
                                       "Type": "String",
                                       "Optional": true,
-                                      "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                                      "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                                       "ConflictsWith": [
                                         "metadata.0.name"
                                       ]
@@ -963,7 +963,7 @@
                                     },
                                     "resource_version": {
                                       "Type": "String",
-                                      "Description": "An opaque value that represents the internal version of this job that can be used by clients to determine when job has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                      "Description": "An opaque value that represents the internal version of this job that can be used by clients to determine when job has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                                       "Computed": true
                                     },
                                     "self_link": {
@@ -5328,7 +5328,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard daemonset's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard daemonset's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -5348,7 +5348,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -5388,7 +5388,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this daemonset that can be used by clients to determine when daemonset has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this daemonset that can be used by clients to determine when daemonset has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -5541,7 +5541,7 @@
                   "metadata": {
                     "Type": "List",
                     "Required": true,
-                    "Description": "Standard daemon set's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "Description": "Standard daemon set's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                     "MaxItems": 1,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -5561,7 +5561,7 @@
                         "generate_name": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                           "ConflictsWith": [
                             "metadata.0.name"
                           ]
@@ -5592,7 +5592,7 @@
                         },
                         "resource_version": {
                           "Type": "String",
-                          "Description": "An opaque value that represents the internal version of this daemon set that can be used by clients to determine when daemon set has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "Description": "An opaque value that represents the internal version of this daemon set that can be used by clients to determine when daemon set has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                           "Computed": true
                         },
                         "self_link": {
@@ -9914,7 +9914,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard deployment's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard deployment's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -9934,7 +9934,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -9974,7 +9974,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this deployment that can be used by clients to determine when deployment has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this deployment that can be used by clients to determine when deployment has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -10163,7 +10163,7 @@
                   "metadata": {
                     "Type": "List",
                     "Required": true,
-                    "Description": "Standard pod's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "Description": "Standard pod's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                     "MaxItems": 1,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -10183,7 +10183,7 @@
                         "generate_name": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                           "ConflictsWith": [
                             "metadata.name"
                           ]
@@ -10219,7 +10219,7 @@
                         },
                         "resource_version": {
                           "Type": "String",
-                          "Description": "An opaque value that represents the internal version of this pod that can be used by clients to determine when pod has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "Description": "An opaque value that represents the internal version of this pod that can be used by clients to determine when pod has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                           "Computed": true
                         },
                         "self_link": {
@@ -14536,7 +14536,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard endpoints's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard endpoints's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -14556,7 +14556,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -14596,7 +14596,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this endpoints that can be used by clients to determine when endpoints has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this endpoints that can be used by clients to determine when endpoints has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -14717,7 +14717,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard horizontal pod autoscaler's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard horizontal pod autoscaler's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -14737,7 +14737,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -14777,7 +14777,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this horizontal pod autoscaler that can be used by clients to determine when horizontal pod autoscaler has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this horizontal pod autoscaler that can be used by clients to determine when horizontal pod autoscaler has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -14796,7 +14796,7 @@
       "spec": {
         "Type": "List",
         "Required": true,
-        "Description": "Behaviour of the autoscaler. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+        "Description": "Behaviour of the autoscaler. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -15308,7 +15308,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard ingress's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard ingress's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -15328,7 +15328,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -15368,7 +15368,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this ingress that can be used by clients to determine when ingress has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this ingress that can be used by clients to determine when ingress has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -15534,7 +15534,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard job's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard job's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -15554,7 +15554,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -15595,7 +15595,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this job that can be used by clients to determine when job has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this job that can be used by clients to determine when job has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -15718,7 +15718,7 @@
                   "metadata": {
                     "Type": "List",
                     "Required": true,
-                    "Description": "Standard job's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "Description": "Standard job's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                     "MaxItems": 1,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -15738,7 +15738,7 @@
                         "generate_name": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                           "ConflictsWith": [
                             "metadata.0.name"
                           ]
@@ -15769,7 +15769,7 @@
                         },
                         "resource_version": {
                           "Type": "String",
-                          "Description": "An opaque value that represents the internal version of this job that can be used by clients to determine when job has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "Description": "An opaque value that represents the internal version of this job that can be used by clients to determine when job has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                           "Computed": true
                         },
                         "self_link": {
@@ -20091,7 +20091,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard limit range's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard limit range's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -20111,7 +20111,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -20151,7 +20151,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this limit range that can be used by clients to determine when limit range has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this limit range that can be used by clients to determine when limit range has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -20170,7 +20170,7 @@
       "spec": {
         "Type": "List",
         "Optional": true,
-        "Description": "Spec defines the limits enforced. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+        "Description": "Spec defines the limits enforced. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -20228,7 +20228,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard mutating webhook configuration's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard mutating webhook configuration's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -20248,7 +20248,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.0.name"
               ]
@@ -20279,7 +20279,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this mutating webhook configuration that can be used by clients to determine when mutating webhook configuration has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this mutating webhook configuration that can be used by clients to determine when mutating webhook configuration has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -20594,7 +20594,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard namespace's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard namespace's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -20614,7 +20614,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.0.name"
               ]
@@ -20645,7 +20645,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this namespace that can be used by clients to determine when namespace has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this namespace that can be used by clients to determine when namespace has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -20666,7 +20666,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard network policy's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard network policy's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -20686,7 +20686,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -20726,7 +20726,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this network policy that can be used by clients to determine when network policy has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this network policy that can be used by clients to determine when network policy has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -21181,7 +21181,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard persistent volume's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard persistent volume's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -21221,7 +21221,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this persistent volume that can be used by clients to determine when persistent volume has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this persistent volume that can be used by clients to determine when persistent volume has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -22063,7 +22063,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard persistent volume claim's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard persistent volume claim's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -22083,7 +22083,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -22123,7 +22123,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this persistent volume claim that can be used by clients to determine when persistent volume claim has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this persistent volume claim that can be used by clients to determine when persistent volume claim has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -22265,7 +22265,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard pod's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard pod's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -22285,7 +22285,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -22325,7 +22325,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this pod that can be used by clients to determine when pod has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this pod that can be used by clients to determine when pod has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -26640,7 +26640,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard pod disruption budget's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard pod disruption budget's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -26660,7 +26660,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -26700,7 +26700,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this pod disruption budget that can be used by clients to determine when pod disruption budget has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this pod disruption budget that can be used by clients to determine when pod disruption budget has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -26808,7 +26808,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard priority class's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard priority class's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -26828,7 +26828,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.0.name"
               ]
@@ -26859,7 +26859,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this priority class that can be used by clients to determine when priority class has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this priority class that can be used by clients to determine when priority class has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -26890,7 +26890,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard replication controller's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard replication controller's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -26910,7 +26910,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -26950,7 +26950,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this replication controller that can be used by clients to determine when replication controller has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this replication controller that can be used by clients to determine when replication controller has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -30219,7 +30219,7 @@
                   "metadata": {
                     "Type": "List",
                     "Optional": true,
-                    "Description": "Standard replication controller's template's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "Description": "Standard replication controller's template's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                     "Computed": true,
                     "MaxItems": 1,
                     "IsBlock": true,
@@ -30240,7 +30240,7 @@
                         "generate_name": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                           "ConflictsWith": [
                             "metadata.name"
                           ]
@@ -30276,7 +30276,7 @@
                         },
                         "resource_version": {
                           "Type": "String",
-                          "Description": "An opaque value that represents the internal version of this replication controller's template that can be used by clients to determine when replication controller's template has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "Description": "An opaque value that represents the internal version of this replication controller's template that can be used by clients to determine when replication controller's template has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                           "Computed": true
                         },
                         "self_link": {
@@ -35763,7 +35763,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard resource quota's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard resource quota's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -35783,7 +35783,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -35823,7 +35823,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this resource quota that can be used by clients to determine when resource quota has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this resource quota that can be used by clients to determine when resource quota has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -35842,7 +35842,7 @@
       "spec": {
         "Type": "List",
         "Optional": true,
-        "Description": "Spec defines the desired quota. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+        "Description": "Spec defines the desired quota. https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -35876,7 +35876,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard role's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard role's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -35896,7 +35896,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -35936,7 +35936,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this role that can be used by clients to determine when role has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this role that can be used by clients to determine when role has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -36009,7 +36009,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard roleBinding's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard roleBinding's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -36058,7 +36058,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this roleBinding that can be used by clients to determine when roleBinding has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this roleBinding that can be used by clients to determine when roleBinding has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -36150,7 +36150,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard secret's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard secret's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -36170,7 +36170,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -36210,7 +36210,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -36262,7 +36262,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard service's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard service's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -36282,7 +36282,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -36322,7 +36322,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -36341,7 +36341,7 @@
       "spec": {
         "Type": "List",
         "Required": true,
-        "Description": "Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+        "Description": "Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -36351,7 +36351,7 @@
             "cluster_ip": {
               "Type": "String",
               "Optional": true,
-              "Description": "The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
+              "Description": "The IP address of the service. It is usually assigned randomly by the oligarch. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
               "Computed": true
             },
             "external_ips": {
@@ -36503,7 +36503,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard service account's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard service account's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -36523,7 +36523,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -36563,7 +36563,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this service account that can be used by clients to determine when service account has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this service account that can be used by clients to determine when service account has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -36601,7 +36601,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard stateful set's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard stateful set's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -36621,7 +36621,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.name"
               ]
@@ -36661,7 +36661,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this stateful set that can be used by clients to determine when stateful set has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this stateful set that can be used by clients to determine when stateful set has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -36777,7 +36777,7 @@
                   "metadata": {
                     "Type": "List",
                     "Required": true,
-                    "Description": "Standard stateful set's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "Description": "Standard stateful set's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                     "MaxItems": 1,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -36797,7 +36797,7 @@
                         "generate_name": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                           "ConflictsWith": [
                             "metadata.0.name"
                           ]
@@ -36828,7 +36828,7 @@
                         },
                         "resource_version": {
                           "Type": "String",
-                          "Description": "An opaque value that represents the internal version of this stateful set that can be used by clients to determine when stateful set has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "Description": "An opaque value that represents the internal version of this stateful set that can be used by clients to determine when stateful set has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                           "Computed": true
                         },
                         "self_link": {
@@ -41191,7 +41191,7 @@
                   "metadata": {
                     "Type": "List",
                     "Required": true,
-                    "Description": "Standard persistent volume claim's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "Description": "Standard persistent volume claim's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
                     "MaxItems": 1,
                     "IsBlock": true,
                     "ConfigImplicitMode": "Block",
@@ -41211,7 +41211,7 @@
                         "generate_name": {
                           "Type": "String",
                           "Optional": true,
-                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                          "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
                           "ConflictsWith": [
                             "metadata.name"
                           ]
@@ -41251,7 +41251,7 @@
                         },
                         "resource_version": {
                           "Type": "String",
-                          "Description": "An opaque value that represents the internal version of this persistent volume claim that can be used by clients to determine when persistent volume claim has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "Description": "An opaque value that represents the internal version of this persistent volume claim that can be used by clients to determine when persistent volume claim has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
                           "Computed": true
                         },
                         "self_link": {
@@ -41395,7 +41395,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard storage class's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard storage class's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -41415,7 +41415,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.0.name"
               ]
@@ -41446,7 +41446,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this storage class that can be used by clients to determine when storage class has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this storage class that can be used by clients to determine when storage class has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -41505,7 +41505,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard validating webhook configuration's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard validating webhook configuration's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -41525,7 +41525,7 @@
             "generate_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "Description": "Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#idempotency",
               "ConflictsWith": [
                 "metadata.0.name"
               ]
@@ -41556,7 +41556,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this validating webhook configuration that can be used by clients to determine when validating webhook configuration has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this validating webhook configuration that can be used by clients to determine when validating webhook configuration has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -41883,7 +41883,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard config_map's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard config_map's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -41932,7 +41932,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this config_map that can be used by clients to determine when config_map has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this config_map that can be used by clients to determine when config_map has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -41972,7 +41972,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard ingress's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard ingress's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -42021,7 +42021,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this ingress that can be used by clients to determine when ingress has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this ingress that can be used by clients to determine when ingress has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -42176,7 +42176,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard namespace's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard namespace's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -42216,7 +42216,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this namespace that can be used by clients to determine when namespace has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this namespace that can be used by clients to determine when namespace has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -42265,7 +42265,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard secret's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard secret's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -42314,7 +42314,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -42359,7 +42359,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard service's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard service's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -42408,7 +42408,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -42426,7 +42426,7 @@
       },
       "spec": {
         "Type": "List",
-        "Description": "Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+        "Description": "Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
         "Computed": true,
         "MaxItems": 1,
         "IsBlock": true,
@@ -42436,7 +42436,7 @@
           "Info": {
             "cluster_ip": {
               "Type": "String",
-              "Description": "The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
+              "Description": "The IP address of the service. It is usually assigned randomly by the oligarch. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
               "Computed": true
             },
             "external_ips": {
@@ -42571,7 +42571,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard service account's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard service account's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -42620,7 +42620,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this service account that can be used by clients to determine when service account has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this service account that can be used by clients to determine when service account has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {
@@ -42663,7 +42663,7 @@
       "metadata": {
         "Type": "List",
         "Required": true,
-        "Description": "Standard storage class's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata",
+        "Description": "Standard storage class's metadata. More info: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#metadata",
         "MaxItems": 1,
         "IsBlock": true,
         "ConfigImplicitMode": "Block",
@@ -42703,7 +42703,7 @@
             },
             "resource_version": {
               "Type": "String",
-              "Description": "An opaque value that represents the internal version of this storage class that can be used by clients to determine when storage class has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "Description": "An opaque value that represents the internal version of this storage class that can be used by clients to determine when storage class has changed. Read more: https://github.com/kubernetes/community/blob/oligarch/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
               "Computed": true
             },
             "self_link": {

--- a/terraform/model/providers/linode.json
+++ b/terraform/model/providers/linode.json
@@ -62,10 +62,10 @@
         "Optional": true,
         "Description": "The group this Domain belongs to. This is for display purposes only."
       },
-      "master_ips": {
+      "oligarch_ips": {
         "Type": "Set",
         "Optional": true,
-        "Description": "The IP addresses representing the master DNS for this Domain.",
+        "Description": "The IP addresses representing the oligarch DNS for this Domain.",
         "ConfigImplicitMode": "Attr",
         "Elem": {
           "Type": "SchemaElements",
@@ -85,7 +85,7 @@
       "soa_email": {
         "Type": "String",
         "Optional": true,
-        "Description": "Start of Authority email address. This is required for master Domains."
+        "Description": "Start of Authority email address. This is required for oligarch Domains."
       },
       "status": {
         "Type": "String",
@@ -112,8 +112,8 @@
       "type": {
         "Type": "String",
         "Required": true,
-        "Description": "If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave).",
-        "InputDefault": "master"
+        "Description": "If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a oligarch (also called a politician).",
+        "InputDefault": "oligarch"
       }
     },
     "linode_domain_record": {
@@ -1816,9 +1816,9 @@
         "Type": "String",
         "Optional": true
       },
-      "master_ips": {
+      "oligarch_ips": {
         "Type": "Set",
-        "Description": "The IP addresses representing the master DNS for this Domain.",
+        "Description": "The IP addresses representing the oligarch DNS for this Domain.",
         "Computed": true,
         "ConfigImplicitMode": "Attr",
         "Elem": {
@@ -1838,7 +1838,7 @@
       },
       "soa_email": {
         "Type": "String",
-        "Description": "Start of Authority email address. This is required for master Domains.",
+        "Description": "Start of Authority email address. This is required for oligarch Domains.",
         "Computed": true
       },
       "status": {
@@ -1863,7 +1863,7 @@
       },
       "type": {
         "Type": "String",
-        "Description": "If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave).",
+        "Description": "If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a oligarch (also called a politician).",
         "Computed": true
       }
     },

--- a/terraform/model/providers/mongodbatlas.json
+++ b/terraform/model/providers/mongodbatlas.json
@@ -223,7 +223,7 @@
         "Type": "String",
         "Computed": true
       },
-      "master_key_uuid": {
+      "oligarch_key_uuid": {
         "Type": "String",
         "Computed": true
       },
@@ -1742,7 +1742,7 @@
         "Type": "String",
         "Computed": true
       },
-      "master_key_uuid": {
+      "oligarch_key_uuid": {
         "Type": "String",
         "Computed": true
       },
@@ -2069,7 +2069,7 @@
               "Type": "String",
               "Computed": true
             },
-            "master_key_uuid": {
+            "oligarch_key_uuid": {
               "Type": "String",
               "Computed": true
             },

--- a/terraform/model/providers/nks.json
+++ b/terraform/model/providers/nks.json
@@ -199,7 +199,7 @@
         "Type": "Int",
         "Required": true
       },
-      "startup_master_size": {
+      "startup_oligarch_size": {
         "Type": "String",
         "Optional": true
       },
@@ -320,7 +320,7 @@
         }
       }
     },
-    "nks_master_node": {
+    "nks_oligarch_node": {
       "cluster_id": {
         "Type": "Int",
         "Required": true

--- a/terraform/model/providers/ns1.json
+++ b/terraform/model/providers/ns1.json
@@ -1045,7 +1045,7 @@
           "additional_primaries"
         ]
       },
-      "hostmaster": {
+      "hostoligarch": {
         "Type": "String",
         "Computed": true
       },
@@ -1288,7 +1288,7 @@
         "Type": "Int",
         "Computed": true
       },
-      "hostmaster": {
+      "hostoligarch": {
         "Type": "String",
         "Computed": true
       },

--- a/terraform/model/providers/oci.json
+++ b/terraform/model/providers/oci.json
@@ -1408,7 +1408,7 @@
         "Type": "Bool",
         "Required": true
       },
-      "master_node": {
+      "oligarch_node": {
         "Type": "List",
         "Required": true,
         "MaxItems": 1,
@@ -12935,7 +12935,7 @@
           "Value": "String"
         }
       },
-      "external_masters": {
+      "external_oligarchs": {
         "Type": "List",
         "Optional": true,
         "Computed": true,
@@ -23810,7 +23810,7 @@
         "Type": "Bool",
         "Computed": true
       },
-      "master_node": {
+      "oligarch_node": {
         "Type": "List",
         "Computed": true,
         "MaxItems": 1,
@@ -24167,7 +24167,7 @@
               "Type": "Bool",
               "Computed": true
             },
-            "master_node": {
+            "oligarch_node": {
               "Type": "List",
               "Computed": true,
               "MaxItems": 1,
@@ -51162,7 +51162,7 @@
                 "Value": "String"
               }
             },
-            "external_masters": {
+            "external_oligarchs": {
               "Type": "List",
               "Computed": true,
               "IsBlock": true,

--- a/terraform/model/providers/okta.json
+++ b/terraform/model/providers/okta.json
@@ -1615,7 +1615,7 @@
         "Required": true,
         "Description": "Subschema unique string identifier"
       },
-      "master": {
+      "oligarch": {
         "Type": "String",
         "Optional": true,
         "Description": "SubSchema profile manager, if not set it will inherit its setting."
@@ -1715,7 +1715,7 @@
         "Required": true,
         "Description": "Subschema unique string identifier"
       },
-      "master": {
+      "oligarch": {
         "Type": "String",
         "Optional": true,
         "Description": "SubSchema profile manager, if not set it will inherit its setting."
@@ -2600,7 +2600,7 @@
         "Required": true,
         "Description": "name of idp"
       },
-      "profile_master": {
+      "profile_oligarch": {
         "Type": "Bool",
         "Optional": true
       },
@@ -2828,7 +2828,7 @@
         "Required": true,
         "Description": "name of idp"
       },
-      "profile_master": {
+      "profile_oligarch": {
         "Type": "Bool",
         "Optional": true
       },
@@ -3044,7 +3044,7 @@
           "Value": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
         }
       },
-      "profile_master": {
+      "profile_oligarch": {
         "Type": "Bool",
         "Optional": true
       },
@@ -3290,7 +3290,7 @@
         "Required": true,
         "Description": "name of idp"
       },
-      "profile_master": {
+      "profile_oligarch": {
         "Type": "Bool",
         "Optional": true
       },
@@ -5758,7 +5758,7 @@
           "Value": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
         }
       },
-      "profile_master": {
+      "profile_oligarch": {
         "Type": "Bool",
         "Optional": true
       },
@@ -6376,7 +6376,7 @@
         "Required": true,
         "Description": "name of idp"
       },
-      "profile_master": {
+      "profile_oligarch": {
         "Type": "Bool",
         "Optional": true
       },
@@ -7106,7 +7106,7 @@
         "Required": true,
         "Description": "Subschema unique string identifier"
       },
-      "master": {
+      "oligarch": {
         "Type": "String",
         "Optional": true,
         "Description": "SubSchema profile manager, if not set it will inherit its setting."
@@ -7202,7 +7202,7 @@
         "Required": true,
         "Description": "Subschema unique string identifier"
       },
-      "master": {
+      "oligarch": {
         "Type": "String",
         "Optional": true,
         "Description": "SubSchema profile manager, if not set it will inherit its setting."

--- a/terraform/model/providers/openstack.json
+++ b/terraform/model/providers/openstack.json
@@ -1613,7 +1613,7 @@
         "Optional": true,
         "Computed": true
       },
-      "master_addresses": {
+      "oligarch_addresses": {
         "Type": "List",
         "Computed": true,
         "ConfigImplicitMode": "Attr",
@@ -1622,12 +1622,12 @@
           "ElementsType": "String"
         }
       },
-      "master_count": {
+      "oligarch_count": {
         "Type": "Int",
         "Optional": true,
         "Computed": true
       },
-      "master_flavor": {
+      "oligarch_flavor": {
         "Type": "String",
         "Optional": true,
         "Computed": true
@@ -1753,12 +1753,12 @@
         "Type": "Map",
         "Optional": true
       },
-      "master_flavor": {
+      "oligarch_flavor": {
         "Type": "String",
         "Optional": true,
         "DefaultFunc": "ENV(OS_MAGNUM_MASTER_FLAVOR)"
       },
-      "master_lb_enabled": {
+      "oligarch_lb_enabled": {
         "Type": "Bool",
         "Optional": true
       },
@@ -2124,7 +2124,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "ConfigImplicitMode": "Attr",
@@ -6790,7 +6790,7 @@
         "Type": "Map",
         "Computed": true
       },
-      "master_addresses": {
+      "oligarch_addresses": {
         "Type": "List",
         "Computed": true,
         "ConfigImplicitMode": "Attr",
@@ -6799,11 +6799,11 @@
           "ElementsType": "String"
         }
       },
-      "master_count": {
+      "oligarch_count": {
         "Type": "Int",
         "Computed": true
       },
-      "master_flavor": {
+      "oligarch_flavor": {
         "Type": "String",
         "Computed": true
       },
@@ -6919,11 +6919,11 @@
         "Type": "Map",
         "Computed": true
       },
-      "master_flavor": {
+      "oligarch_flavor": {
         "Type": "String",
         "Computed": true
       },
-      "master_lb_enabled": {
+      "oligarch_lb_enabled": {
         "Type": "Bool",
         "Computed": true
       },
@@ -6996,7 +6996,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "Computed": true,

--- a/terraform/model/providers/opentelekomcloud.json
+++ b/terraform/model/providers/opentelekomcloud.json
@@ -3095,7 +3095,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Computed": true,
         "ConfigImplicitMode": "Attr",
@@ -5063,7 +5063,7 @@
         "Elem": {
           "Type": "SchemaInfo",
           "Info": {
-            "active_master": {
+            "active_oligarch": {
               "Type": "Bool",
               "Optional": true,
               "Computed": true
@@ -5236,38 +5236,38 @@
         "Optional": true,
         "Computed": true
       },
-      "master_data_volume_count": {
+      "oligarch_data_volume_count": {
         "Type": "Int",
         "Optional": true,
         "Computed": true
       },
-      "master_data_volume_size": {
+      "oligarch_data_volume_size": {
         "Type": "Int",
         "Optional": true,
         "Computed": true
       },
-      "master_data_volume_type": {
+      "oligarch_data_volume_type": {
         "Type": "String",
         "Optional": true,
         "Computed": true
       },
-      "master_node_ip": {
+      "oligarch_node_ip": {
         "Type": "String",
         "Computed": true
       },
-      "master_node_num": {
+      "oligarch_node_num": {
         "Type": "Int",
         "Required": true
       },
-      "master_node_product_id": {
+      "oligarch_node_product_id": {
         "Type": "String",
         "Computed": true
       },
-      "master_node_size": {
+      "oligarch_node_size": {
         "Type": "String",
         "Required": true
       },
-      "master_node_spec_id": {
+      "oligarch_node_spec_id": {
         "Type": "String",
         "Computed": true
       },
@@ -5300,7 +5300,7 @@
         "Type": "String",
         "Computed": true
       },
-      "slave_security_groups_id": {
+      "politician_security_groups_id": {
         "Type": "String",
         "Computed": true
       },

--- a/terraform/model/providers/powerdns.json
+++ b/terraform/model/providers/powerdns.json
@@ -68,7 +68,7 @@
         "Type": "String",
         "Required": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "ConfigImplicitMode": "Attr",

--- a/terraform/model/providers/rancher2.json
+++ b/terraform/model/providers/rancher2.json
@@ -1206,7 +1206,7 @@
         "Optional": true,
         "Default": {
           "Type": "string",
-          "Value": "master"
+          "Value": "oligarch"
         }
       },
       "cluster_id": {
@@ -1719,7 +1719,7 @@
               "Optional": true,
               "Description": "The resource group of an existing Azure Log Analytics Workspace to use for storing monitoring data. If not specified, uses the 'Cluster' resource group"
             },
-            "master_dns_prefix": {
+            "oligarch_dns_prefix": {
               "Type": "String",
               "Required": true,
               "Description": "DNS prefix to use the Kubernetes cluster control pane"
@@ -2104,7 +2104,7 @@
             "kubernetes_version": {
               "Type": "String",
               "Required": true,
-              "Description": "The kubernetes master version"
+              "Description": "The kubernetes oligarch version"
             },
             "maximum_nodes": {
               "Type": "Int",
@@ -2322,10 +2322,10 @@
                 "Value": "false"
               }
             },
-            "enable_master_authorized_network": {
+            "enable_oligarch_authorized_network": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "Whether or not master authorized network is enabled",
+              "Description": "Whether or not oligarch authorized network is enabled",
               "Default": {
                 "Type": "bool",
                 "Value": "false"
@@ -2352,7 +2352,7 @@
             "enable_private_endpoint": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "Whether the master's internal IP address is used as the cluster endpoint",
+              "Description": "Whether the oligarch's internal IP address is used as the cluster endpoint",
               "Default": {
                 "Type": "bool",
                 "Value": "false"
@@ -2482,25 +2482,25 @@
               "Required": true,
               "Description": "When to performance updates on the nodes, in 24-hour time"
             },
-            "master_authorized_network_cidr_blocks": {
+            "oligarch_authorized_network_cidr_blocks": {
               "Type": "List",
               "Optional": true,
-              "Description": "Define up to 10 external networks that could access Kubernetes master through HTTPS",
+              "Description": "Define up to 10 external networks that could access Kubernetes oligarch through HTTPS",
               "ConfigImplicitMode": "Attr",
               "Elem": {
                 "Type": "SchemaElements",
                 "ElementsType": "String"
               }
             },
-            "master_ipv4_cidr_block": {
+            "oligarch_ipv4_cidr_block": {
               "Type": "String",
               "Required": true,
-              "Description": "The IP range in CIDR notation to use for the hosted master network"
+              "Description": "The IP range in CIDR notation to use for the hosted oligarch network"
             },
-            "master_version": {
+            "oligarch_version": {
               "Type": "String",
               "Required": true,
-              "Description": "The kubernetes master version"
+              "Description": "The kubernetes oligarch version"
             },
             "max_node_count": {
               "Type": "Int",
@@ -4694,10 +4694,10 @@
                     "Elem": {
                       "Type": "SchemaInfo",
                       "Info": {
-                        "debug_master": {
+                        "debug_oligarch": {
                           "Type": "Bool",
                           "Optional": true,
-                          "Description": "Debug master",
+                          "Description": "Debug oligarch",
                           "Default": {
                             "Type": "bool",
                             "Value": "false"
@@ -7833,10 +7833,10 @@
                                 "Elem": {
                                   "Type": "SchemaInfo",
                                   "Info": {
-                                    "debug_master": {
+                                    "debug_oligarch": {
                                       "Type": "Bool",
                                       "Optional": true,
-                                      "Description": "Debug master",
+                                      "Description": "Debug oligarch",
                                       "Default": {
                                         "Type": "bool",
                                         "Value": "false"
@@ -12518,7 +12518,7 @@
               "Optional": true,
               "Description": "The resource group of an existing Azure Log Analytics Workspace to use for storing monitoring data. If not specified, uses the 'Cluster' resource group"
             },
-            "master_dns_prefix": {
+            "oligarch_dns_prefix": {
               "Type": "String",
               "Required": true,
               "Description": "DNS prefix to use the Kubernetes cluster control pane"
@@ -12875,7 +12875,7 @@
             "kubernetes_version": {
               "Type": "String",
               "Required": true,
-              "Description": "The kubernetes master version"
+              "Description": "The kubernetes oligarch version"
             },
             "maximum_nodes": {
               "Type": "Int",
@@ -13078,10 +13078,10 @@
                 "Value": "false"
               }
             },
-            "enable_master_authorized_network": {
+            "enable_oligarch_authorized_network": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "Whether or not master authorized network is enabled",
+              "Description": "Whether or not oligarch authorized network is enabled",
               "Default": {
                 "Type": "bool",
                 "Value": "false"
@@ -13108,7 +13108,7 @@
             "enable_private_endpoint": {
               "Type": "Bool",
               "Optional": true,
-              "Description": "Whether the master's internal IP address is used as the cluster endpoint",
+              "Description": "Whether the oligarch's internal IP address is used as the cluster endpoint",
               "Default": {
                 "Type": "bool",
                 "Value": "false"
@@ -13238,25 +13238,25 @@
               "Required": true,
               "Description": "When to performance updates on the nodes, in 24-hour time"
             },
-            "master_authorized_network_cidr_blocks": {
+            "oligarch_authorized_network_cidr_blocks": {
               "Type": "List",
               "Optional": true,
-              "Description": "Define up to 10 external networks that could access Kubernetes master through HTTPS",
+              "Description": "Define up to 10 external networks that could access Kubernetes oligarch through HTTPS",
               "ConfigImplicitMode": "Attr",
               "Elem": {
                 "Type": "SchemaElements",
                 "ElementsType": "String"
               }
             },
-            "master_ipv4_cidr_block": {
+            "oligarch_ipv4_cidr_block": {
               "Type": "String",
               "Required": true,
-              "Description": "The IP range in CIDR notation to use for the hosted master network"
+              "Description": "The IP range in CIDR notation to use for the hosted oligarch network"
             },
-            "master_version": {
+            "oligarch_version": {
               "Type": "String",
               "Required": true,
-              "Description": "The kubernetes master version"
+              "Description": "The kubernetes oligarch version"
             },
             "max_node_count": {
               "Type": "Int",
@@ -15432,10 +15432,10 @@
                     "Elem": {
                       "Type": "SchemaInfo",
                       "Info": {
-                        "debug_master": {
+                        "debug_oligarch": {
                           "Type": "Bool",
                           "Optional": true,
-                          "Description": "Debug master",
+                          "Description": "Debug oligarch",
                           "Default": {
                             "Type": "bool",
                             "Value": "false"
@@ -16254,10 +16254,10 @@
               "Elem": {
                 "Type": "SchemaInfo",
                 "Info": {
-                  "debug_master": {
+                  "debug_oligarch": {
                     "Type": "Bool",
                     "Optional": true,
-                    "Description": "Debug master",
+                    "Description": "Debug oligarch",
                     "Default": {
                       "Type": "bool",
                       "Value": "false"
@@ -18460,10 +18460,10 @@
                                 "Elem": {
                                   "Type": "SchemaInfo",
                                   "Info": {
-                                    "debug_master": {
+                                    "debug_oligarch": {
                                       "Type": "Bool",
                                       "Optional": true,
-                                      "Description": "Debug master",
+                                      "Description": "Debug oligarch",
                                       "Default": {
                                         "Type": "bool",
                                         "Value": "false"

--- a/terraform/model/providers/scaleway.json
+++ b/terraform/model/providers/scaleway.json
@@ -1172,7 +1172,7 @@
             },
             "host": {
               "Type": "String",
-              "Description": "The kubernetes master URL",
+              "Description": "The kubernetes oligarch URL",
               "Computed": true
             },
             "token": {

--- a/terraform/model/providers/selectel.json
+++ b/terraform/model/providers/selectel.json
@@ -706,7 +706,7 @@
           "Value": "ipv4"
         }
       },
-      "master_region": {
+      "oligarch_region": {
         "Type": "String",
         "Required": true
       },
@@ -745,7 +745,7 @@
           }
         }
       },
-      "slave_region": {
+      "politician_region": {
         "Type": "String",
         "Required": true
       },

--- a/terraform/model/providers/spotinst.json
+++ b/terraform/model/providers/spotinst.json
@@ -411,11 +411,11 @@
               "Type": "Bool",
               "Optional": true
             },
-            "master_host": {
+            "oligarch_host": {
               "Type": "String",
               "Required": true
             },
-            "master_port": {
+            "oligarch_port": {
               "Type": "Int",
               "Required": true
             }
@@ -760,11 +760,11 @@
               "Type": "Bool",
               "Optional": true
             },
-            "master_host": {
+            "oligarch_host": {
               "Type": "String",
               "Required": true
             },
-            "master_port": {
+            "oligarch_port": {
               "Type": "Int",
               "Required": true
             }
@@ -784,7 +784,7 @@
               "Type": "String",
               "Required": true
             },
-            "master_host": {
+            "oligarch_host": {
               "Type": "String",
               "Required": true
             },
@@ -2681,11 +2681,11 @@
         "Elem": {
           "Type": "SchemaInfo",
           "Info": {
-            "master_host": {
+            "oligarch_host": {
               "Type": "String",
               "Required": true
             },
-            "master_port": {
+            "oligarch_port": {
               "Type": "Int",
               "Required": true
             }
@@ -3364,11 +3364,11 @@
         "Elem": {
           "Type": "SchemaInfo",
           "Info": {
-            "master_host": {
+            "oligarch_host": {
               "Type": "String",
               "Required": true
             },
-            "master_port": {
+            "oligarch_port": {
               "Type": "Int",
               "Required": true
             }
@@ -4601,7 +4601,7 @@
         "Type": "String",
         "Optional": true
       },
-      "master_ebs_block_device": {
+      "oligarch_ebs_block_device": {
         "Type": "Set",
         "Optional": true,
         "IsBlock": true,
@@ -4628,11 +4628,11 @@
           }
         }
       },
-      "master_ebs_optimized": {
+      "oligarch_ebs_optimized": {
         "Type": "Bool",
         "Optional": true
       },
-      "master_instance_types": {
+      "oligarch_instance_types": {
         "Type": "List",
         "Optional": true,
         "ConfigImplicitMode": "Attr",
@@ -4641,7 +4641,7 @@
           "ElementsType": "String"
         }
       },
-      "master_lifecycle": {
+      "oligarch_lifecycle": {
         "Type": "String",
         "Optional": true
       },

--- a/terraform/model/providers/telefonicaopencloud.json
+++ b/terraform/model/providers/telefonicaopencloud.json
@@ -1331,7 +1331,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "ConfigImplicitMode": "Attr",
@@ -2714,7 +2714,7 @@
         "Type": "String",
         "Optional": true
       },
-      "masters": {
+      "oligarchs": {
         "Type": "Set",
         "Optional": true,
         "Computed": true,

--- a/terraform/model/providers/tencentcloud.json
+++ b/terraform/model/providers/tencentcloud.json
@@ -1530,7 +1530,7 @@
             "backup_server_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Host header used when accessing the backup origin server. If left empty, the ServerName of master origin server will be used by default."
+              "Description": "Host header used when accessing the backup origin server. If left empty, the ServerName of oligarch origin server will be used by default."
             },
             "cos_private_access": {
               "Type": "String",
@@ -1568,7 +1568,7 @@
             "server_name": {
               "Type": "String",
               "Optional": true,
-              "Description": "Host header used when accessing the master origin server. If left empty, the acceleration domain name will be used by default."
+              "Description": "Host header used when accessing the oligarch origin server. If left empty, the acceleration domain name will be used by default."
             }
           }
         }
@@ -5752,7 +5752,7 @@
           "ElementsType": "String"
         }
       },
-      "master_config": {
+      "oligarch_config": {
         "Type": "List",
         "Optional": true,
         "Description": "Deploy the machine configuration information of the 'MASTER_ETCD' service, and create \u003c=7 units for common users.",
@@ -6741,7 +6741,7 @@
       "nodes_per_shard": {
         "Type": "Int",
         "Required": true,
-        "Description": "Number of nodes per shard, at least 3(one master and two slaves)."
+        "Description": "Number of nodes per shard, at least 3(one oligarch and two politicians)."
       },
       "password": {
         "Type": "String",
@@ -7364,10 +7364,10 @@
           "Value": "5.7"
         }
       },
-      "first_slave_zone": {
+      "first_politician_zone": {
         "Type": "String",
         "Optional": true,
-        "Description": "Zone information about first slave instance."
+        "Description": "Zone information about first politician instance."
       },
       "force_delete": {
         "Type": "Bool",
@@ -7489,12 +7489,12 @@
       "root_password": {
         "Type": "String",
         "Required": true,
-        "Description": "Password of root account. This parameter can be specified when you purchase master instances, but it should be ignored when you purchase read-only instances or disaster recovery instances."
+        "Description": "Password of root account. This parameter can be specified when you purchase oligarch instances, but it should be ignored when you purchase read-only instances or disaster recovery instances."
       },
-      "second_slave_zone": {
+      "second_politician_zone": {
         "Type": "String",
         "Optional": true,
-        "Description": "Zone information about second slave instance."
+        "Description": "Zone information about second politician instance."
       },
       "security_groups": {
         "Type": "Set",
@@ -7506,7 +7506,7 @@
           "ElementsType": "String"
         }
       },
-      "slave_deploy_mode": {
+      "politician_deploy_mode": {
         "Type": "Int",
         "Optional": true,
         "Description": "Availability zone deployment method. Available values: 0 - Single availability zone; 1 - Multiple availability zones.",
@@ -7515,7 +7515,7 @@
           "Value": "0"
         }
       },
-      "slave_sync_mode": {
+      "politician_sync_mode": {
         "Type": "Int",
         "Optional": true,
         "Description": "Data replication mode. 0 - Async replication; 1 - Semisync replication; 2 - Strongsync replication.",
@@ -7738,10 +7738,10 @@
         "Description": "Indicates whether the instance is locked. 0 - No; 1 - Yes.",
         "Computed": true
       },
-      "master_instance_id": {
+      "oligarch_instance_id": {
         "Type": "String",
         "Required": true,
-        "Description": "Indicates the master instance ID of recovery instances."
+        "Description": "Indicates the oligarch instance ID of recovery instances."
       },
       "mem_size": {
         "Type": "Int",
@@ -7994,7 +7994,7 @@
       "root_password": {
         "Type": "String",
         "Required": true,
-        "Description": "Password of root account. This parameter can be specified when you purchase master instances, but it should be ignored when you purchase read-only instances or disaster recovery instances."
+        "Description": "Password of root account. This parameter can be specified when you purchase oligarch instances, but it should be ignored when you purchase read-only instances or disaster recovery instances."
       },
       "storage": {
         "Type": "Int",
@@ -8110,7 +8110,7 @@
       "redis_replicas_num": {
         "Type": "Int",
         "Optional": true,
-        "Description": "The number of instance copies. This is not required for standalone and master slave versions.",
+        "Description": "The number of instance copies. This is not required for standalone and oligarch politician versions.",
         "Default": {
           "Type": "int",
           "Value": "1"
@@ -8119,7 +8119,7 @@
       "redis_shard_num": {
         "Type": "Int",
         "Optional": true,
-        "Description": "The number of instance shard. This is not required for standalone and master slave versions.",
+        "Description": "The number of instance shard. This is not required for standalone and oligarch politician versions.",
         "Default": {
           "Type": "int",
           "Value": "1"
@@ -8154,7 +8154,7 @@
       "type": {
         "Type": "String",
         "Optional": true,
-        "Description": "Instance type. Available values: `cluster_ckv`,`cluster_redis5.0`,`cluster_redis`,`master_slave_ckv`,`master_slave_redis5.0`,`master_slave_redis`,`standalone_redis`, specific region support specific types, need to refer data `tencentcloud_redis_zone_config`.",
+        "Description": "Instance type. Available values: `cluster_ckv`,`cluster_redis5.0`,`cluster_redis`,`oligarch_politician_ckv`,`oligarch_politician_redis5.0`,`oligarch_politician_redis`,`standalone_redis`, specific region support specific types, need to refer data `tencentcloud_redis_zone_config`.",
         "Deprecated": "It has been deprecated from version 1.33.1. Please use 'type_id' instead."
       },
       "type_id": {
@@ -11206,7 +11206,7 @@
                   },
                   "backup_server_name": {
                     "Type": "String",
-                    "Description": "Host header used when accessing the backup origin server. If left empty, the ServerName of master origin server will be used by default.",
+                    "Description": "Host header used when accessing the backup origin server. If left empty, the ServerName of oligarch origin server will be used by default.",
                     "Computed": true
                   },
                   "cos_private_access": {
@@ -11236,7 +11236,7 @@
                   },
                   "server_name": {
                     "Type": "String",
-                    "Description": "Host header used when accessing the master origin server. If left empty, the acceleration domain name will be used by default.",
+                    "Description": "Host header used when accessing the oligarch origin server. If left empty, the acceleration domain name will be used by default.",
                     "Computed": true
                   }
                 }
@@ -17729,7 +17729,7 @@
             },
             "instance_role": {
               "Type": "String",
-              "Description": "Instance type. Supported values include: master - master instance, dr - disaster recovery instance, and ro - read-only instance.",
+              "Description": "Instance type. Supported values include: oligarch - oligarch instance, dr - disaster recovery instance, and ro - read-only instance.",
               "Computed": true
             },
             "internet_host": {
@@ -17757,9 +17757,9 @@
               "Description": "Transport layer port number for internal purpose.",
               "Computed": true
             },
-            "master_instance_id": {
+            "oligarch_instance_id": {
               "Type": "String",
-              "Description": "Indicates the master instance ID of recovery instances.",
+              "Description": "Indicates the oligarch instance ID of recovery instances.",
               "Computed": true
             },
             "memory_size": {
@@ -17792,7 +17792,7 @@
                 "ElementsType": "String"
               }
             },
-            "slave_sync_mode": {
+            "politician_sync_mode": {
               "Type": "Int",
               "Description": "Data replication mode. 0 - Async replication; 1 - Semisync replication; 2 - Strongsync replication.",
               "Computed": true
@@ -17833,7 +17833,7 @@
       "instance_role": {
         "Type": "String",
         "Optional": true,
-        "Description": "Instance type. Supported values include: master - master instance, dr - disaster recovery instance, and ro - read-only instance."
+        "Description": "Instance type. Supported values include: oligarch - oligarch instance, dr - disaster recovery instance, and ro - read-only instance."
       },
       "limit": {
         "Type": "Int",
@@ -17884,10 +17884,10 @@
         "Optional": true,
         "Description": "Indicates whether to query disaster recovery instances."
       },
-      "with_master": {
+      "with_oligarch": {
         "Type": "Int",
         "Optional": true,
-        "Description": "Indicates whether to query master instances."
+        "Description": "Indicates whether to query oligarch instances."
       },
       "with_ro": {
         "Type": "Int",
@@ -18004,9 +18004,9 @@
                 "ElementsType": "String"
               }
             },
-            "first_slave_zones": {
+            "first_politician_zones": {
               "Type": "List",
-              "Description": "Zone information about first slave instance.",
+              "Description": "Zone information about first politician instance.",
               "Computed": true,
               "ConfigImplicitMode": "Attr",
               "Elem": {
@@ -18047,9 +18047,9 @@
                 "ElementsType": "Int"
               }
             },
-            "second_slave_zones": {
+            "second_politician_zones": {
               "Type": "List",
-              "Description": "Zone information about second slave instance.",
+              "Description": "Zone information about second politician instance.",
               "Computed": true,
               "ConfigImplicitMode": "Attr",
               "Elem": {
@@ -18098,7 +18098,7 @@
                 }
               }
             },
-            "slave_deploy_modes": {
+            "politician_deploy_modes": {
               "Type": "List",
               "Description": "Availability zone deployment method. Available values: 0 - Single availability zone; 1 - Multiple availability zones.",
               "Computed": true,
@@ -18108,7 +18108,7 @@
                 "ElementsType": "Int"
               }
             },
-            "support_slave_sync_modes": {
+            "support_politician_sync_modes": {
               "Type": "List",
               "Description": "Data replication mode. 0 - Async replication; 1 - Semisync replication; 2 - Strongsync replication.",
               "Computed": true,
@@ -18634,7 +18634,7 @@
             },
             "type": {
               "Type": "String",
-              "Description": "Instance type. Available values: master_slave_redis, master_slave_ckv, cluster_ckv, cluster_redis and standalone_redis.",
+              "Description": "Instance type. Available values: oligarch_politician_redis, oligarch_politician_ckv, cluster_ckv, cluster_redis and standalone_redis.",
               "Computed": true,
               "Deprecated": "It has been deprecated from version 1.33.1. Please use 'type_id' instead."
             },
@@ -18729,7 +18729,7 @@
             },
             "type": {
               "Type": "String",
-              "Description": "Instance type. Available values: master_slave_redis, master_slave_ckv, cluster_ckv, cluster_redis and standalone_redis.",
+              "Description": "Instance type. Available values: oligarch_politician_redis, oligarch_politician_ckv, cluster_ckv, cluster_redis and standalone_redis.",
               "Computed": true,
               "Deprecated": "It has been deprecated from version 1.33.1. Please use 'type_id' instead."
             },

--- a/terraform/model/providers/yandex.json
+++ b/terraform/model/providers/yandex.json
@@ -2537,7 +2537,7 @@
           "ElementsType": "String"
         }
       },
-      "master": {
+      "oligarch": {
         "Type": "List",
         "Required": true,
         "MaxItems": 1,
@@ -2618,7 +2618,7 @@
               "Computed": true,
               "MaxItems": 1,
               "ConflictsWith": [
-                "master.0.zonal"
+                "oligarch.0.zonal"
               ],
               "IsBlock": true,
               "ConfigImplicitMode": "Block",
@@ -2691,7 +2691,7 @@
               "Computed": true,
               "MaxItems": 1,
               "ConflictsWith": [
-                "master.0.regional"
+                "oligarch.0.regional"
               ],
               "IsBlock": true,
               "ConfigImplicitMode": "Block",
@@ -7328,7 +7328,7 @@
           "ElementsType": "String"
         }
       },
-      "master": {
+      "oligarch": {
         "Type": "List",
         "Computed": true,
         "MaxItems": 1,

--- a/terraform/model/provisioners.list
+++ b/terraform/model/provisioners.list
@@ -4,4 +4,4 @@ habitat
 local-exec
 puppet
 remote-exec
-salt-masterless
+salt-oligarchless

--- a/terraform/model/provisioners/salt-masterless.json
+++ b/terraform/model/provisioners/salt-masterless.json
@@ -1,7 +1,7 @@
 {
   ".schema_version": "2",
   ".sdk_type": "builtin",
-  "name": "salt-masterless",
+  "name": "salt-oligarchless",
   "type": "provisioner",
   "version": "v0.13.0-beta3",
   "schema": {


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.